### PR TITLE
Add basic template for audio pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+.gems/

--- a/_data/data.yml
+++ b/_data/data.yml
@@ -1,0 +1,2311 @@
+objects:
+- Content:
+    contents: "john_wieners_i006-11-119.mp3\n\nJohn Wieners\n00:00:00\nReads \u201C\
+      Invocation to Summer\u201D [recording begins abruptly].\n \nJohn Wieners\n00:01:09\n\
+      \"Invitation Au Voyage: II\". Do you know that poem of Baudelaire's [https://www.wikidata.org/wiki/Q501]?\
+      \ It's something at the end of the world. He\u2019s speaking to his beloved,\
+      \ very simple. You know, lots of the German Romanticism was very simple.\n \n\
+      John Wieners\n00:01:30\nReads \"Invitation Au Voyage: II\".\n \nJohn Wieners\n\
+      00:03:15\nWell let's go back to the old poems then, that have been published.\
+      \ Stuart Montgomery, well it doesn't matter. But that--I can send it off to\
+      \ England [https://www.wikidata.org/wiki/Q21] to the Fulcrum Press [https://www.wikidata.org/wiki/Q5507820]\
+      \ doing a lot of Basil Bunting [https://www.wikidata.org/wiki/Q2886803] and\
+      \ the English poet of 65, resuscitated in America [https://www.wikidata.org/wiki/Q30]\
+      \ again, it's about time.\n \nJohn Wieners\n00:03:44\nReads \"Long Nook\" [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:04:38\nI'll just make random choices.\
+      \ \"At Big Sur\".\n \nJohn Wieners\n00:04:53\nReads \"At Big Sur\u201D [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:05:12\n\"Louise\".\n \nJohn Wieners\n\
+      00:05:21\nReads \"Louise\" [from Ace of Pentacles].\n \nJohn Wieners\n00:05:48\n\
+      \"The Pool of Light\".\n \nJohn Wieners\n00:05:53\nReads \"The Pool of Light\"\
+      \ [from Ace of Pentacles].\n \nJohn Wieners\n00:06:14\nFor Mari--No, this is\
+      \ \u201CFor Marion\".\n \nJohn Wieners\n00:06:19\nReads \"For Marion\" [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:07:05\n\u201CThe Mermaid Song\u201D\
+      , forgive me for this, I thought the other poems would carry me through, but\
+      \ I'm reading and keeping with the mood for tonight, it seems to be more lyrical.\
+      \ \"The Serpent's Hiss\".\n \nJohn Wieners\n00:07:52\nReads \"The Serpent's\
+      \ Hiss\" [published later in Selected Poems, 1958-1984].\n \nJohn Wieners\n\
+      00:08:37\nAnd this is called \"Tuesday, 5 pm\".\n \nJohn Wieners\n00:08:43\n\
+      Reads \"Tuesday, 5 pm\" [published later as \u201CTuesday 7:00 PM\u201D in Selected\
+      \ Poems, 1958-1984].\n \nJohn Wieners\n00:10:45\nI'm going to read the \"The\
+      \ Imperatrice\". Ace of Pentacles is a card in the Tarot deck, but the book\
+      \ should be called \u2018pente\u2019 which all the words that appeared in a\
+      \ hypnagogic vision, hypnagogic is the state between waking and sleeping, it's\
+      \ what Jung [https://www.wikidata.org/wiki/Q41532] practiced and his Marie Louise\
+      \ Franz would take down the things that came to him in the state between waking\
+      \ and sleeping and the letters \u2018pente\u2019 appeared in that state and\
+      \ I didn't know what they meant so I kept hunting around and I made the word\
+      \ 'pinnacles' out of it and somebody said why don't you call it \"Ace of Pinnacles\"\
+      \ and we made a whole thing about the Tarot deck, but that's not the title of\
+      \ the book. It should be \u2018pente\u2019 and that's from the Greek  which\
+      \ is \u2018wall\u2019. And I'd like have as a fronts piece for the book William\
+      \ Blake's [https://www.wikidata.org/wiki/Q41513] \"The Chimney Sweep\"  [https://www.wikidata.org/wiki/Q2587725]\
+      \ the second version of that from the \"Songs of Experience\" [https://www.wikidata.org/wiki/Q27890603]\
+      \ when he says that my mum and father have gone up to the church to pray and\
+      \ they make a heaven of my misery. That kind of thing. Imperatrice there's another\
+      \ card from the Tarot deck it's the third card of the deck.\n \nJohn Wieners\n\
+      00:12:09\nReads \"The Imperatrice\" [published later in Selected Poems, 1958-1984].\n\
+      \ \nJohn Wieners\n00:13:38\nThere is something else I thought I'd like to read\
+      \ after that one. I'll read a poem for Sylvia Plath [https://www.wikidata.org/wiki/Q133054]\
+      \ who was an American poet who married an English man, Ted Hughes [https://www.wikidata.org/wiki/Q272194]\
+      \ and had mental troubles and wrote a novel about it called The Bell Jar [https://www.wikidata.org/wiki/Q1213085]\
+      \ under a pseudonym Victoria Lucas, so not to embarrass her mother, and then\
+      \ things became too much for her and I think in 1963, she did away with herself\
+      \ in London [https://www.wikidata.org/wiki/Q84], and it was a great loss, some\
+      \ people feel that and some do not, they feel that at least--Lowell has written\
+      \ an introduction to her poems posthumously printed called Ariel [https://www.wikidata.org/wiki/Q224733]\
+      \ and her first book was The Colossus [https://www.wikidata.org/wiki/Q29889462].\
+      \ But Victoria Lucas was, The Bell Jar, was, you could buy it through William\
+      \ Hiderman and it came down from Canada [https://www.wikidata.org/wiki/Q16]\
+      \ to the United States and it's never been printed in the country. This is \"\
+      The Suicide\".\n \nJohn Wieners\n00:15:06\nReads \"The Suicide\" [published\
+      \ later in Selected Poems, 1958-1984].\n \nJohn Wieners\n00:16:57\nLet's read\
+      \ some happy poems, I'm getting depressed.\n\nUnknown\n00:17:03\n[Cut or edit\
+      \ made in tape].\n\nJohn Wieners\n00:17:04\nReads \"Ode on a Common Fountain\"\
+      \ [from Ace of Pentacles; recording jumps to mid-poem].\n \nJohn Wieners\n00:19:51\n\
+      That's the first poem, I ever, I was twenty, so that was twelve years ago, that\
+      \ poem was written. Now I can go back--I'm still writing about Acis [https://www.wikidata.org/wiki/Q419156]\
+      \ and Galatea [https://www.wikidata.org/wiki/Q241070] but these are terribly\
+      \ sentimental and distraught, drunken poems, you can call them. Maybe we'll\
+      \ have one more, or is that anything from that first reading that you'd like\
+      \ to hear again? I'd rather not go into it. [Unknown audience member suggests\
+      \ poem. Title unintelligible]. Okay, that's what Spender [https://www.wikidata.org/wiki/Q448764]\
+      \ did say to me, he said you look like a de-frocked priest, so. Which I thought\
+      \ was awfully cruel, but I think I am one, my sister was a nun, I'll be a priest.\
+      \ Poets are priests, you know.\n \nJohn Wieners\n00:20:54\nReads \u201CThere\
+      \ are holy orders in life...\u201D [published later in Selected Poems, 1958-1984].\n\
+      \ \nEND\n00:21:42\n"
+    notes: John Wieners reads from Ace of Pentacles (Carr & Wilson, 1964) as well
+      as works published in 1985 in Selected Poems, 1958-1984 (Black Sparrow Press).
+  Contributors:
+  - id: 1
+  Creators:
+  - dates: 1934-2002
+    id: 1
+    name: Wieners, John
+    notes: " American poet, playwright and essayist John Wieners was born in Boston\
+      \ on January 6, 1934. In 1934, Wieners earned a B.A. in English from Boston\
+      \ College, and subsequently worked at Harvard University\u2019s Lamont Library.\
+      \ A 1955 poetry reading by Charles Olson inspired Wieners to attend Black Mountain\
+      \ College in North Carolina, where he met and was mentored by Charles Olson\
+      \ and Robert Duncan. After completing studies in 1956, John Wieners moved back\
+      \ to Boston and started Measure, a (short-lived) literary magazine, as well\
+      \ as becoming involved in the Poet\u2019s Theater in Cambridge. At the age of\
+      \ 24, (in 1958) Wieners moved to San Francisco and met Beat Poets Jack Kerouac,\
+      \ Jack Spicer and Allen Ginsberg, and published his first book of poems, The\
+      \ Hotel Wentley Poems (Dave Haselwood Publishing, 1965). John Wieners\u2019\
+      \ San Francisco journal, The Journal of John Wieners Is To Be Called 707 Scott\
+      \ Street for Billie Holiday, 1959, was published in 1966 by Sun & Moon Press.\
+      \ Wieners wrote plays that were never published during this time, until 1964\
+      \ when he published Ace of Pentacles (published by James F. Carr & Robert A.\
+      \ Wilson). Charles Olson asked Wieners to be a graduate student and a teaching\
+      \ assistant at the State University of New York at Buffalo in 1965, and Wieners\
+      \ eventually became the university\u2019s chair of poetics, when he left by\
+      \ 1967. John Wieners suffered from mental illness, and was institutionalized\
+      \ for the second time in 1969, where he wrote Asylum Poems (For My Father) (Press\
+      \ of the Black Flag Raised). In 1970, he published Nerves (Cape Goliard Press),\
+      \ an internationally published book of poetry, and between 1967 to 1972, he\
+      \ published six smaller books of poetry. Behind the State Capitol; or, Cincinnati\
+      \ Pike (Good Gay Poets Press) was published in 1975 and thus marked the last\
+      \ of his published poems. John Wieners\u2019 poetry, while highly appraised\
+      \ by Beat Poets, Black Mountain Poets and his peers, did not achieve wide public\
+      \ acclaim or readership. In 1985, however, Selected Poems, 1958-1984 (Black\
+      \ Sparrow Press) was compiled with the help of Robert Creeley and Allen Ginsberg.\
+      \ In the 70\u2019s, John Wieners lived and became involved with anti-war movements\
+      \ and became an activist for gay rights, living at 44 Joy Street in Boston.\
+      \ Becoming more and more reclusive after the mid 70\u2019s, John Wieners died\
+      \ of an apparent stroke on March 1, 2002. Michael Carr edited a posthumous collection\
+      \ of Wiener\u2019s 1971 journals which was published in 2007."
+    role:
+    - id: 5dde95a512e691.44238013
+      value: Author
+    - id: 5fac4be6bddc86.93102225
+      value: Performer
+    url: ' http://viaf.org/viaf/90723960'
+  Dates:
+  - date: 1966 10 08
+    id: 1
+    source: Previous researcher
+    type: Performance Date
+  Digital_File_Description:
+  - content_type: Sound Recording
+    contents: "John Wieners\n00:00:00\nReads \u201CInvocation to Summer\u201D [recording\
+      \ begins abruptly].\n \nJohn Wieners\n00:01:09\n\"Invitation Au Voyage: II\"\
+      . Do you know that poem of Baudelaire's [https://www.wikidata.org/wiki/Q501]?\
+      \ It's something at the end of the world. He\u2019s speaking to his beloved,\
+      \ very simple. You know, lots of the German Romanticism was very simple.\n \n\
+      John Wieners\n00:01:30\nReads \"Invitation Au Voyage: II\".\n \nJohn Wieners\n\
+      00:03:15\nWell let's go back to the old poems then, that have been published.\
+      \ Stuart Montgomery, well it doesn't matter. But that--I can send it off to\
+      \ England [https://www.wikidata.org/wiki/Q21] to the Fulcrum Press [https://www.wikidata.org/wiki/Q5507820]\
+      \ doing a lot of Basil Bunting [https://www.wikidata.org/wiki/Q2886803] and\
+      \ the English poet of 65, resuscitated in America [https://www.wikidata.org/wiki/Q30]\
+      \ again, it's about time.\n \nJohn Wieners\n00:03:44\nReads \"Long Nook\" [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:04:38\nI'll just make random choices.\
+      \ \"At Big Sur\".\n \nJohn Wieners\n00:04:53\nReads \"At Big Sur\u201D [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:05:12\n\"Louise\".\n \nJohn Wieners\n\
+      00:05:21\nReads \"Louise\" [from Ace of Pentacles].\n \nJohn Wieners\n00:05:48\n\
+      \"The Pool of Light\".\n \nJohn Wieners\n00:05:53\nReads \"The Pool of Light\"\
+      \ [from Ace of Pentacles].\n \nJohn Wieners\n00:06:14\nFor Mari--No, this is\
+      \ \u201CFor Marion\".\n \nJohn Wieners\n00:06:19\nReads \"For Marion\" [from\
+      \ Ace of Pentacles].\n \nJohn Wieners\n00:07:05\n\u201CThe Mermaid Song\u201D\
+      , forgive me for this, I thought the other poems would carry me through, but\
+      \ I'm reading and keeping with the mood for tonight, it seems to be more lyrical.\
+      \ \"The Serpent's Hiss\".\n \nJohn Wieners\n00:07:52\nReads \"The Serpent's\
+      \ Hiss\" [published later in Selected Poems, 1958-1984].\n \nJohn Wieners\n\
+      00:08:37\nAnd this is called \"Tuesday, 5 pm\".\n \nJohn Wieners\n00:08:43\n\
+      Reads \"Tuesday, 5 pm\" [published later as \u201CTuesday 7:00 PM\u201D in Selected\
+      \ Poems, 1958-1984].\n \nJohn Wieners\n00:10:45\nI'm going to read the \"The\
+      \ Imperatrice\". Ace of Pentacles is a card in the Tarot deck, but the book\
+      \ should be called \u2018pente\u2019 which all the words that appeared in a\
+      \ hypnagogic vision, hypnagogic is the state between waking and sleeping, it's\
+      \ what Jung [https://www.wikidata.org/wiki/Q41532] practiced and his Marie Louise\
+      \ Franz would take down the things that came to him in the state between waking\
+      \ and sleeping and the letters \u2018pente\u2019 appeared in that state and\
+      \ I didn't know what they meant so I kept hunting around and I made the word\
+      \ 'pinnacles' out of it and somebody said why don't you call it \"Ace of Pinnacles\"\
+      \ and we made a whole thing about the Tarot deck, but that's not the title of\
+      \ the book. It should be \u2018pente\u2019 and that's from the Greek  which\
+      \ is \u2018wall\u2019. And I'd like have as a fronts piece for the book William\
+      \ Blake's [https://www.wikidata.org/wiki/Q41513] \"The Chimney Sweep\"  [https://www.wikidata.org/wiki/Q2587725]\
+      \ the second version of that from the \"Songs of Experience\" [https://www.wikidata.org/wiki/Q27890603]\
+      \ when he says that my mum and father have gone up to the church to pray and\
+      \ they make a heaven of my misery. That kind of thing. Imperatrice there's another\
+      \ card from the Tarot deck it's the third card of the deck.\n \nJohn Wieners\n\
+      00:12:09\nReads \"The Imperatrice\" [published later in Selected Poems, 1958-1984].\n\
+      \ \nJohn Wieners\n00:13:38\nThere is something else I thought I'd like to read\
+      \ after that one. I'll read a poem for Sylvia Plath [https://www.wikidata.org/wiki/Q133054]\
+      \ who was an American poet who married an English man, Ted Hughes [https://www.wikidata.org/wiki/Q272194]\
+      \ and had mental troubles and wrote a novel about it called The Bell Jar [https://www.wikidata.org/wiki/Q1213085]\
+      \ under a pseudonym Victoria Lucas, so not to embarrass her mother, and then\
+      \ things became too much for her and I think in 1963, she did away with herself\
+      \ in London [https://www.wikidata.org/wiki/Q84], and it was a great loss, some\
+      \ people feel that and some do not, they feel that at least--Lowell has written\
+      \ an introduction to her poems posthumously printed called Ariel [https://www.wikidata.org/wiki/Q224733]\
+      \ and her first book was The Colossus [https://www.wikidata.org/wiki/Q29889462].\
+      \ But Victoria Lucas was, The Bell Jar, was, you could buy it through William\
+      \ Hiderman and it came down from Canada [https://www.wikidata.org/wiki/Q16]\
+      \ to the United States and it's never been printed in the country. This is \"\
+      The Suicide\".\n \nJohn Wieners\n00:15:06\nReads \"The Suicide\" [published\
+      \ later in Selected Poems, 1958-1984].\n \nJohn Wieners\n00:16:57\nLet's read\
+      \ some happy poems, I'm getting depressed.\n\nUnknown\n00:17:03\n[Cut or edit\
+      \ made in tape].\n\nJohn Wieners\n00:17:04\nReads \"Ode on a Common Fountain\"\
+      \ [from Ace of Pentacles; recording jumps to mid-poem].\n \nJohn Wieners\n00:19:51\n\
+      That's the first poem, I ever, I was twenty, so that was twelve years ago, that\
+      \ poem was written. Now I can go back--I'm still writing about Acis [https://www.wikidata.org/wiki/Q419156]\
+      \ and Galatea [https://www.wikidata.org/wiki/Q241070] but these are terribly\
+      \ sentimental and distraught, drunken poems, you can call them. Maybe we'll\
+      \ have one more, or is that anything from that first reading that you'd like\
+      \ to hear again? I'd rather not go into it. [Unknown audience member suggests\
+      \ poem. Title unintelligible]. Okay, that's what Spender [https://www.wikidata.org/wiki/Q448764]\
+      \ did say to me, he said you look like a de-frocked priest, so. Which I thought\
+      \ was awfully cruel, but I think I am one, my sister was a nun, I'll be a priest.\
+      \ Poets are priests, you know.\n \nJohn Wieners\n00:20:54\nReads \u201CThere\
+      \ are holy orders in life...\u201D [published later in Selected Poems, 1958-1984].\n\
+      \ \nEND\n00:21:42"
+    duration: 00:21:42
+    featured: 'Yes'
+    file_path: files.spokenweb.ca>concordia>sgw>audio>all_mp3
+    file_url: https://files.spokenweb.ca/concordia/sgw/audio/all_mp3/john_wieners_i006-11-119.mp3
+    filename: john_wieners_i006-11-119.mp3
+    id: 1
+    notes: "John Wieners reads from Ace of Pentacles (Carr & Wilson, 1964) as well\
+      \ as works published in 1985 in Selected Poems, 1958-1984 (Black Sparrow Press).\n\
+      \n00:00- Reading \u201CInvitation to Summer\u201D [recording does not start\
+      \ at beginning of poem]\n01:09- Introduces \u201CInvitation Au Voyage\u201D\
+      \ [INDEX: German Romanticism]\n01:30- Reads \u201CInvitation Au Voyage\u201D\
+      \n03:15- Introduces \u201CLong Nook\u201D [Howard Fink list \u201COne Look\u201D\
+      ] [INDEX: Stuart Montgommery, Fulcrum Press, Basil Bunting]\n03:44- Reads \u201C\
+      Long Nook\u201D\n04:38- Introduces \u201CAt Big Sur\u201D\n04:53- Reads \u201C\
+      At Big Sur\u201D\n05:12- Introduces \u201CLouise\u201D\n05:21- Reads \u201C\
+      Louise\u201D\n05:48- Introduces \u201CThe Pool of Light\u201D\n05:53- Reads\
+      \ \u201CThe Pool of Light\u201D\n06:14- Introduces \u201CNot For Marion\u201D\
+      \ [Howard Fink List \u201CI have found her snow white in my head\u201D]\n06:19-\
+      \ Reads \u201CFor Marion\u201D\n07:05- Introduces \u201CThe Serpent\u2019s Hiss\u201D\
+      \n07:52- Reads \u201CThe Serpent\u2019s Hiss\u201D\n08:37- Introduces \u201C\
+      Tuesday, 5 pm\u201D [published as \u201CTuesday 7:00 PM\u201D]\n08:43- Reads\
+      \ \u201CTuesday, 5 pm\u201D\n10:45- Introduces \u201CImperatrice\u201D [INDEX:\
+      \ Ace of Pentacles, Tarot, hypnogogic, Karl Yung, Marie Louise Franz, William\
+      \ Blake\u2019s \u201CThe Chimney Sweep\u201D, \u201CSongs of Experience\u201D\
+      ]\n12:09- Reads \u201CImperatrice\u201D\n13:38- Introduces \u201CThe Suicide\u201D\
+      \ [INDEX: Sylvia Plath, Ted Hughes, mental illness, The Bell Jar 1963, Ariel,\
+      \ The Colossus, Victoria Lucas, William Hiderman]\n15:06- Reads \u201CThe Suicide\u201D\
+      \n17:04- Introduces unknown poem, mid-sentence \u201CAbout your pipes and mouth...\u201D\
+      \ [Howard Fink first line \u201CIn patience wait the flooding...\u201D]\n19:51-\
+      \ Introduces unknown poem \u201CI was born to be a priest...\u201D [Howard Fink\
+      \ first line \u201CThere are holy orders in life...] [INDEX: Asis, Galatea,\
+      \ Spender]\n20:54- Reads unknown poem\n21:24.91- END OF RECORDING\n"
+    size: 52.1 MB
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0119_back.jpg
+    id: 2
+    title: John Wieners Tape Box - Back
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0119_front.jpg
+    id: 3
+    title: John Wieners Tape Box - Front
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0119_side.jpg
+    id: 4
+    title: John Wieners Tape Box - Spine
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0119_tape.jpg
+    id: 5
+    title: John Wieners Tape Box - Reel
+  Item_Description:
+    genre:
+    - id: 5fac4b69363493.67050777
+      value: 'Reading: Poetry'
+    language: English
+    production_context: Documentary recording
+    source_item_ID: I006-11-119
+    swallow1_id: '1390'
+    title: John Wieners at Sir George Williams University, The Poetry Series, 8 October
+      1966
+    title_note: '"J. WIENES I006/SR119" written on sticker on the spine of the tape''s
+      box. J. WIENES refers to John Wieners. Wieners is mispelled '
+    title_source: Catalgouer
+  Location:
+  - address: 1455, Boul de Maisonneuve Ouest, Montreal, Quebec, Canada
+    id: 1
+    latitude: '45.4972758'
+    longitude: '-73.57893043'
+    url: https://www.openstreetmap.org/way/22080570
+    venue: Hall Building Art Gallery
+  Material_Description:
+  - AV_type: Audio
+    extent: 1/4 inch
+    id: 1
+    material_designation: Reel to Reel
+    physical_composition: Magnetic Tape
+    playback_mode: Mono
+    playing_speed: 7 1/2 ips
+    recording_type: Analogue
+    sound_quality: Good
+    tape_brand: Scotch
+    track_configuration: Half-track
+  Notes:
+  - id: 1
+    note: "Year-Specific Information:\n\n From 1965-67, John Wieners was at State\
+      \ University of New York (SUNY) at Buffalo, either working as a graduate student\
+      \ or as the chair of poetics. At that time, Charles Olson left SUNY in 1966,\
+      \ to be replaced by Robert Creeley. Wieners\u2019 The Journal of John Wieners\
+      \ Is To Be Called 707 Scott Street for Billie Holiday, 1959, was published in\
+      \ 1966."
+    type: General
+  - id: 2
+    note: "Local Connections:\n\nNo direct connections between John Wieners and Sir\
+      \ George Williams University are known, however Wieners was an important poet,\
+      \ connected with poets from both the Black Mountain school and Beat movements.\
+      \ \n"
+    type: General
+  - id: 3
+    note: 'Original transcript, research, introduction and edits by Celyn Harding-Jones
+
+
+      Additional research and edits by Ali Barillaro.'
+    type: Cataloguer
+  - id: 4
+    note: Reel-to-reel tape>CD>digital file (mp3)
+    type: Preservation
+  Related_Works:
+  - URL: https://www.worldcat.org/title/oxford-encyclopedia-of-american-literature/oclc/769478515&referer=brief_results
+    citation: 'Foster, Edward Halsey. "Gay Literature: Poetry and Prose". The Oxford
+      Encyclopedia of American Literature. Jay Parini (ed). Oxford University Press,
+      2004. '
+    id: 1
+  - URL: https://www.independent.co.uk/news/obituaries/john-wieners-9143191.html
+    citation: "Ward, Geoff. \u201CJohn Joseph Wieners, poet, Jan. 6th 1934 - March\
+      \ 1st 2002\u201D. The Independent, 15 March 2000."
+    id: 2
+  - URL: https://www.worldcat.org/title/ace-of-pentacles-a-new-book-of-poems-by-john-wieners/oclc/702932793?referer=di&ht=edition
+    citation: 'Wieners, John. Ace of Pentacles. New York: Carr & Wilson, 1964'
+    id: 3
+  - URL: https://www.worldcat.org/title/selected-poems-1958-1984/oclc/743392421&referer=brief_results
+    citation: 'Wieners, John. Selected Poems, 1958-1984. Santa Barbara: Black Sparrow
+      Press, 1985.'
+    id: 4
+  - URL: https://montreal.spokenweb.ca/sgw-poetry-readings/john-wieners-at-sgwu-1966/
+    citation: "Thoms, Kathleen. \u201CPoetry Readings Inaugurated\u201D. The Georgian.\
+      \ Montreal: Sir George Williams University, 10 October 1966, p. 6. "
+    id: 5
+  - citation: "\u201CWieners, John, 1934-\u201D. Literature Online Biography. Literature\
+      \ Online: ProQuest, 2009. "
+    id: 6
+  - URL: https://drive.google.com/drive/folders/12H55HcY0pAZtzJ9AmxLabbX2hdjvCaX0
+    citation: "\u201CPoetry Readings\u201D. OP-ED. Montreal: Sir George Williams University,\
+      \ 6 October 1967, page 6. "
+    id: 7
+  Rights:
+    access: Closed
+  cataloguer:
+    email: masoumehzaare@gmail.com
+    lastname: Zaare
+    name: Masoumeh
+  classification:
+  - URI: ''
+    class_name: subseries
+    id: '39'
+    label: Poetry 1
+    parent_id: '38'
+  - URI: ''
+    class_name: series
+    contact email: ''
+    description: ''
+    id: '38'
+    label: The Poetry Series
+    parent_id: '24'
+    wikidata url: ''
+  - Contributing Unit: Records Management and Archives
+    Old Swallow1 ID: ''
+    Persistent URL: http://archives.concordia.ca/I086
+    Source Collection: SGWU Reading Series-Concordia University Department of English
+      fonds
+    Source Collection Description: The fonds consists of some administrative records
+      of the SGWU Department of English and the Concordia Department of English between
+      1971 and 2000. It also consists of some SGWU Department of English records related
+      to student academic activities in the 1940s and to public readings and lectures,
+      and a few interviews, produced between 1966 and 1972. The fonds mainly includes
+      minutes of departmental meetings and some course timetables. It also includes
+      some student papers in bound volumes and 63 sound recordings (80 audio reels)
+      mainly composed of poetry readings (see the Concordia SpokenWeb project which
+      uses this material) but also a few lectures given at SGWU. There are also loose
+      typed sheets describing some of the SGWU poetry readings.
+    Source Collection ID: I086
+    URI: ''
+    class_name: collection
+    id: '24'
+    label: SGWU Reading Series-Concordia University Department of English fonds
+    parent_id: '4'
+  - URI: ''
+    class_name: partner institution
+    description: ''
+    id: '4'
+    label: Concordia University
+    parent_id: '0'
+  create_date: '2023-01-31 20:57:01'
+  last_modified: '2023-10-19 15:14:50'
+  schema: Swallow JSON
+  schema_definition: spoken_web
+  swallow_id: '1252'
+- Content:
+    contents: "margaret_atwood_i006-11-008.mp3\n\nHenry Beissel\n00:00:00\nOne moment...\
+      \ problem that we have here at Sir George [https://www.wikidata.org/wiki/Q326342].\
+      \ We did try to get a larger hall but it was impossible. To accommodate the\
+      \ overflow, we have set up loudspeakers in the little gallery here, Howard,\
+      \ and in the other one too?\n \nHoward Fink\n00:00:21\nOutside.\n \nHenry Beissel\n\
+      00:00:22\nOutside, there are loudspeakers. So please don't all crowd into the\
+      \ room. If you are going to lean against the paintings, we shall never be able\
+      \ to get this room again for poetry readings. Because this, this is a gallery\
+      \ which belongs to the Fine Arts department, we had great difficulty getting\
+      \ it, these paintings are very precious, particularly to the artists themselves\
+      \ [audience laughter]. I would ask you please to stay away from the paintings.\
+      \ That must have been the artist [audience laughter]. We are also waiting for\
+      \ the arrival of someone else, so please be patient. Howard--[audience laughter]\
+      \ can you ask the security people to turn on the cooling system, the hall is\
+      \ going to be too hot.\n \nUnknown\n00:01:22\nAmbient Sound [voices].\n \nHenry\
+      \ Beissel\n00:01:25\nWe may get 927.\n \nMargaret Atwood\n00:01:30\nWhat do\
+      \ you mean, we may, I think they're also--okay. What would you like to do? Let\
+      \ us stay here or move?\n \nAudience\n00:01:41\nStay here.\n \nMargaret Atwood\n\
+      00:01:44\nOkay, with the people, there are some people who are at the back of\
+      \ the door, there is some space up here at the front if you'd like to come up.\n\
+      \ \nHenry Beissel\n00:01:54\nNo more than ten.\n \nMargaret Atwood\n00:01:58\n\
+      About ten. It'll make more room at the back too...If everybody on the chairs\
+      \ would shift over this way, um, and sit on, sort of as if it were a bench,\
+      \ then some more people can sit on the edges there. Or just move the chairs\
+      \ all that way. Move the rows forward. They're all shifting over anyway. Could\
+      \ you all move your chairs forward to make the rows as close together as possible.\
+      \ Okay, it's alright. \n\nUnknown\n00:03:17\nAmbient Sound [voices].\n\nMargaret\
+      \ Atwood\n00:04:41\nThere are these uhh--woohoo--there are these speakers outside\
+      \ and you might be more comfortable if you went out and listened over the speakers,\
+      \ some of the people are really jammed in there. I don't see any reason why\
+      \ this thing should resemble a steam bath, for all of us. If you're--what? what?...I\
+      \ don't think I can, what is it that they do? [Audience laughter].\n \nWynne\
+      \ Francis\n00:05:19\n[Laughter]. Miss Atwood [https://www.wikidata.org/wiki/Q183492]\
+      \ has just upstaged the introducer. Good evening ladies and gentlemen. It's\
+      \ not often that an artist excels in two medium such as poetry and fiction as\
+      \ our guest tonight does. Miss Atwood's reputation as a superior poet was established\
+      \ in the 60's with her first collections, The Circle Game [https://www.wikidata.org/wiki/Q7723073]\
+      \ and The Animals in that Country [https://www.wikidata.org/wiki/Q7713834].\
+      \ And while continuing to write fine poetry, six major collections to date,\
+      \ she's given  us two novels in the last five years, The Edible Woman [https://www.wikidata.org/wiki/Q7731579]\
+      \ and Surfacing. With the second novel, published late in 1972, within a few\
+      \ months of a controversial work of criticism, Margaret Atwood became one of\
+      \ Canada's [https://www.wikidata.org/wiki/Q16] best known literary artists.\
+      \ The hypothesis of Survival, a study of patterns in Canadian lit is that Canadians\
+      \ see themselves as victims. I was remind of Survival recently when I came across\
+      \ a nineteenth-century curiosity written by one John McTaggart [https://www.wikidata.org/wiki/Q463553].\
+      \ It was a book published in London [https://www.wikidata.org/wiki/Q84] in 19--\
+      \ excuse me--1829. McTaggart wrote \"There's a melancholy which is peculiar\
+      \ to Canadians which must be combatted. People who labor under it must be encouraged,\
+      \ the soothing language, good treatment and now and then as circumstances require,\
+      \ a little assistance gratis as a stimulant.\" McTaggart's third point about\
+      \ the helpful effects of a little assistance as a recent theory has been taken\
+      \ up by the Canada Council [https://www.wikidata.org/wiki/Q2993809], to whom\
+      \ we are in part indebted for her appearance tonight. Margaret Atwood's work\
+      \ constitutes an exploration of what it means to be a Canadian, to be a woman\
+      \ and to be a human being. She writes about our totems, our tapestry of manners,\
+      \ our progressive insanities. She taught at Sir George in 67-68, and it's a\
+      \ great pleasure to have her return to us tonight. After her reading, she'll\
+      \ be open to questions from the audience. Ladies and gentlemen, Margaret Atwood.\n\
+      \nAudience\n00:07:27\nApplause [cuts out briefly].\n\nMargaret Atwood\n00:07:38\n\
+      Let's see now, if the mic starts to get funny, let me know...Too loud?...Not\
+      \ too loud, I'm afraid it isn't a very good mic and also I'm afraid I'm going\
+      \ to have to hold it the whole time which is a bore...I don't think it'll work\
+      \ very well, is that better? Does that work? Higher? Lower? Okay, how's that?\
+      \ Okay, I'm going to read entirely from my new book which is called \"This is\"\
+      --oh, what is it called? [audience laughter]. It's called You Are Happy. Somebody\
+      \ who has been photographing me says that a friend of hers was in a bookstore\
+      \ and picked out this book and thought at first that this was one of these \"\
+      I'm Okay, You're Okay\" books. Until I saw who wrote it. [Audience laughter].\
+      \ But it has a happy ending, you'll be pleased to know. And I'm going to begin\
+      \ at the beginning and end at the end. Skipping portions along the way. I'm\
+      \ also going to make this reading fairly short because we are all in this rather\
+      \ constricted situation. I used to tell people when people in the States [https://www.wikidata.org/wiki/Q30]\
+      \ used to ask me \u201Cdo you live in an igloo\u201D and other questions like\
+      \ that, I used to think to myself that being a Canadian was sort of like living\
+      \ in a chicken coop in the middle of the desert. That everybody was all together\
+      \ in one place but there are these huge spaces around. I wish that  we had been\
+      \ provided with one of them. [Audience laughter]. I have a chicken coop, and\
+      \ you're nicer. But there are more of you. I think we will all have to be very,\
+      \ very patient, unlike the chickens. I'm going to begin by reading a poem called\
+      \ \"Newsreel: Man and Firing Squad\".\n \nMargaret Atwood\n00:10:04\nReads \"\
+      Newsreel: Man and Firing Squad\" from You Are Happy.\n \nMargaret Atwood\n00:11:42\n\
+      Reads \"Useless\" from You Are Happy.\n \nMargaret Atwood\n00:12:35\nThis is--the\
+      \ image in this next poem comes from, begins with the fact that I have a sheep\
+      \ and one of them died. The poem is called \"November\".\n \nMargaret Atwood\n\
+      00:12:48\nReads \"November\" from You Are Happy.\n \nMargaret Atwood\n00:13:52\n\
+      Reads \"Repent\" from You Are Happy.\n \nMargaret Atwood\n00:14:47\n\"Tricks\
+      \ with Mirrors\". How are you doing? Is it hot and steamy? Has anybody died\
+      \ yet?\n \nMargaret Atwood\n00:15:05\nReads \"Tricks with Mirrors\" from You\
+      \ Are Happy.\n \nMargaret Atwood\n00:17:45\nThis is the title poem, \"You Are\
+      \ Happy\".\n \nMargaret Atwood\n00:17:50\nReads \"You are Happy\" from You Are\
+      \ Happy.\n \nMargaret Atwood\n00:18:48\nReads \"First Prayer\" from You Are\
+      \ Happy.\n \nMargaret Atwood\n00:20:25\n\"Is / Not: 1\". Oh boy, is it ever\
+      \ hot in here. I can't stand it. Light. I wonder if we could--well, then I can't\
+      \ see, you see. I wonder if we could turn off--would it be better if we turn\
+      \ off those lights that are grilling you over there...I could what?...Where's\
+      \ the light switch anyway? Howard, turn off the lights?...Well, maybe in a few\
+      \ minutes the lights will go off. Where did\u2026\n\nUnknown\n00:21:36\n[Cut\
+      \ or edit made in tape. Unknown amount of time elapsed]. \n\nMargaret Atwood\n\
+      00:21:37\nHooray, wonderful. Actually, there's a light under here. It's like\
+      \ the Saturday movies [audience laughter]. No, I can read with this, yeah. Maybe\
+      \ I'll just read a little something else here, because it's the Saturday Movies.\n\
+      \ \nMargaret Atwood\n00:22:18\nReads [\"You take my hand\" from Power Politics;\
+      \ audience laughter throughout].\n \nMargaret Atwood\n00:23:13\nAnd since we\
+      \ were talking about the war between Superman [https://www.wikidata.org/wiki/Q79015]\
+      \ and Captain Marvel [https://www.wikidata.org/wiki/Q534153] at dinner, my favourite\
+      \ was Plastic Man [https://www.wikidata.org/wiki/Q746838], but that was an esoteric\
+      \ taste. I'll read this one.\n \nMargaret Atwood\n00:23:28\nReads \"They Eat\
+      \ Out\" [from Power Politics].\n \nMargaret Atwood\n00:24:44\nI go to--I can't\
+      \ resist this. This is from the new book, it's called \"Siren Song\". Students\
+      \ of Seventeenth Century Literature are always asking themselves and each other,\
+      \ what song the sirens sang, and this is the ultimate answer.\n \nMargaret Atwood\n\
+      00:25:06\nReads \"Siren Song\" from You Are Happy.\n \nMargaret Atwood\n00:26:12\n\
+      The imminent critic, Allen Pearson, who was once known when he lived in Montreal\
+      \ [https://www.wikidata.org/wiki/Q340] as the Montreal Poet, now that he lives\
+      \ in Toronto [https://www.wikidata.org/wiki/Q172], he's probably known as the\
+      \ Toronto Poet, says the following: \"Siren Song tells how boring it is for\
+      \ a woman to be obliged to attract men by appealing to them for help\". [Audience\
+      \ laughter]. Um, since I'm on the subject of people in capes and costumes, I'll\
+      \ read...\n \nUnknown\n00:26:56\n[Cut or edit made in tape. Unknown amount of\
+      \ time elapsed].\n\nAnnotation\n00:26:57\nReads [untitled poem from the \u201C\
+      Circle/Mud Poems\u201D section in You Are Happy].\n \nMargaret Atwood\n00:28:20\n\
+      Reads \"Is / Not\" from You Are Happy.\n \nMargaret Atwood\n00:30:37\nI think\
+      \ I'd better read just three more poems, before we all die. The first one is\
+      \ called \"There is Only One of Everything\".\n \nMargaret Atwood\n00:30:54\n\
+      Reads \"There is Only One of Everything\" from You Are Happy.\n \nMargaret Atwood\n\
+      00:32:30\nReads \"Late August\" from You Are Happy.\n \nMargaret Atwood\n00:33:26\n\
+      This is the last poem, called \"Book of Ancestors\".\n \nMargaret Atwood\n00:33:33\n\
+      Reads \"Book of Ancestors\" from You Are Happy. \n \nAudience\n00:36:31\nApplause\
+      \ [cuts out briefly].\n\nWynne Francis\n00:36:47\nThank you, it's really not\
+      \ so hot if you sit still. Miss Atwood is prepared to discuss, for a little\
+      \ while.\n \nMargaret Atwood\n00:37:04\nIf you would like to, uh, I can't see\
+      \ a thing of course, I can sort of see hands if you stick them up and wave them\
+      \ around. Would that be better than turning back on the lights which I'd prefer\
+      \ not to do?\n \nWynne Francis\n00:37:22\nThere's no way we can get mics in\
+      \ the audience, so please speak loudly.\n \nMargaret Atwood\n00:37:23\nI see\
+      \ a hand.\n \nAudience Member 1\n00:37:28\nHow did your nickname of a witch\
+      \ get originated?\n \nMargaret Atwood\n00:37:30\nHow did my nickname of a witch?\
+      \ Are you referring to the speech I gave the other night at Loyola? Oh, it's,\
+      \ I was talking about a couple of reviews, that seemed to credit me with having\
+      \ these supernatural powers, you know, the ability to hypnotize my readers and\
+      \ things like that, and what I was saying was that in fact I don't in fact possess\
+      \ the powers of hypnotism or I'd use them on my bank manager and be quite rich.\
+      \ Um, I was talking about a pattern that seems to crop up from time to time\
+      \ in a certain kind of review usually written by men. [Audience laughter]. I\
+      \ heard that there were a couple of people in the audience at Loyola who before\
+      \ the speech, were convinced that I was a witch and that I was going to talk\
+      \ about witchcraft, and when I said that I wasn't one, they left. [Audience\
+      \ laughter]. You see, if I were a witch, I wouldn't be able to wear the cross.\
+      \ So that's how you can tell I'm not. Wards off vampires. Um, yes?\n \nAudience\
+      \ Member 2\n00:38:54\nUm, [unintelligible] and as well as the Edible Woman,\
+      \ I seem to get this idea of an emergence from greyness, or darkness and I was\
+      \ wondering if it's through this emergence from greyness that you have any reference\
+      \ to Blake [https://www.wikidata.org/wiki/Q41513] in his emergence from chaos.\n\
+      \ \nMargaret Atwood\n00:39:17\nI'll be very flattered, if I did. I'm afraid\
+      \ I suffer by the comparison. I think that you're right in spotting it, I think\
+      \ I would say that it's more like this, that if you want to think in terms of\
+      \ colour, that you start with a grey, and then you go down. Down into, well,\
+      \ it depends on the poem or the book or whatever of what's happening in your\
+      \ life. And, but you have to go down before you come up again otherwise you\
+      \ stay just in the grey part. If you want a real pattern for this, it's Dante's\
+      \ [https://www.wikidata.org/wiki/Q1067] Inferno [https://www.wikidata.org/wiki/Q4509219],\
+      \ where the man starts in a wandering wood, you know he starts in a kind of\
+      \ state of being lost, and then he goes down into hell. The further down he\
+      \ goes the more tortured souls he sees, but when he gets right to the bottom\
+      \ he finds that he's going up again. And then he comes out the other side.\n\
+      \ \nAudience Member 2\n00:40:19\nYeah, but, in this other side-ness in the Edible\
+      \ Woman you come up through colours, a very [unintelligible] of colours and\
+      \ I was wondering if this is the complete emergence of man?\n \nMargaret Atwood\n\
+      00:40:29\nNot complete--I would say no, no beginning.\n \nAudience Member 2\n\
+      00:40:32\n[Unintelligible] complete--into his universal aspect, but into an\
+      \ emergence of man. Into the colours of life.\n \nMargaret Atwood\n00:40:39\n\
+      Your choice of the word 'man' is interesting. Since the heroine is a woman.\
+      \ [Audience laughter and applause]. Um, I think you have the pattern right.\
+      \ I wouldn't like to attach any sort of universal meaning to it.\n \nAudience\
+      \ Member 2\n00:40:56\nNo I'm not attaching a universal meaning, I'm attaching\
+      \ more or less a universal meaning to the colour of darkness or greyness.\n\
+      \ \nMargaret Atwood\n00:41:04\nNo, that's right, you're correct. Yes.\n \nAudience\
+      \ Member 2\n00:41:07\nI'm not trying to express a universal meaning into these\
+      \ colours, this is where you're taking it wrong.\n \nMargaret Atwood\n00:41:14\n\
+      Well, I'm not too sure what we're talking about  to tell you the truth. You've\
+      \ spotted a correct pattern and I'm not too sure how one interprets it because\
+      \ I don't like to be the critic of  my own work in a way if you know what I\
+      \ mean. Yes.\n \nAudience Member 3\n00:41:34\nI know you're writing a screenplay\
+      \ for [unintelligible]. Will it ever become a film?\n \nMargaret Atwood\n00:41:39\n\
+      Will it ever? Let's see now, I finished it at the end of July. Now, what is--the\
+      \ stages of making a film are these: first somebody takes out an option on it,\
+      \ which means they pay you X dollars to have the sole right to try to make the\
+      \ movie for a certain period of time. If they fail to make it to renew the option\
+      \ or to require the rights at the end of that period, you get it back and you\
+      \ can then sell it to anybody else or back to them if you want. That's different\
+      \ from buying the rights which means they've got it. And you can't get it back.\
+      \ An option has been taken out, a script has been written. They are now doing\
+      \ whatever it is they do, who knows. To try to put together what is called a\
+      \ package, that is, they try to interest a director or they pick out a director\
+      \ and they try to put a director together with a script together with some money.\
+      \ And that's all going on, I don't know what's happening with it because they\
+      \ don't tell. Yes.\n \nAudience Member 4\n00:42:42\nAre those people American\
+      \ or Canadian?\n \nMargaret Atwood\n00:42:47\nThese people are. [Audience laughter].\
+      \ Once upon a time there was an English Canadian film industry. Not very hard.\
+      \ I mean it's trying very hard but not many results are being had. And I wanted\
+      \ very much to make Surfacing in Canada with Canadian everything, but I was\
+      \ about two years too late. And also Canadians are quite timmerus about this\
+      \ book because they said \u201Cwell, it'll never be able to sell a film in the\
+      \ States\u201D because of all that strange American symbolism in it. They--the\
+      \ two people I'm working with are two American independent producers, not to\
+      \ be confused with MGM [https://www.wikidata.org/wiki/Q179200], who want to\
+      \ make the book as it is, that is, they like the book, they want to be faithful\
+      \ to it, they don't want to transport it to Maine [https://www.wikidata.org/wiki/Q724]\
+      \ or wherever and make it into an American film, which of course you couldn't\
+      \ do without ruining the symbolic pattern. They want to make it in Canada, they\
+      \ want to put in all that stuff because they say \u201Cwow, dynamite\u201D.\
+      \ [Audience laughter]. They're not worried about selling it in the States. So\
+      \ that's how we're proceeding right now and we have not yet had a falling out\
+      \ on any of the crucial matters such as what's in the screenplay. And so that's\
+      \ been fine. They would like to make it here. And what stage they're at right\
+      \ now I don't know. Now if they don't put it together, then I get it back and\
+      \ then I have another go. And I'll try it \u2018round Canada again, once more,\
+      \ and I'll probably with the same results--\n \nAudience Member 4\n00:44:26\n\
+      You have tried?\n \nMargaret Atwood\n00:44:30\nOh yes, everybody tries. I've\
+      \ written four or five screenplays, none of them have been made. They've all\
+      \ been for Canadians. One thing has happened, I got one television play done,\
+      \ but of course everything you do for the CBC [https://www.wikidata.org/wiki/Q461761]\
+      \ pretty well gets done. [Audience laughter]. As you know. I wrote a screenplay\
+      \ for Edible Woman that didn't get done. I wrote one for Marie-Claire Blais\
+      \ [https://www.wikidata.org/wiki/Q298358], Mad Shadows, we had high hopes for\
+      \ that, that was a Canadian director, Canadian producer all the rest of it.\
+      \ No deal. Film development corporations said it wasn't commercial enough. I\
+      \ mean, you don't go outside before you've been through it for a while. It's\
+      \ a problem that novelists used to face when trying to get their novels published\
+      \ here.\n \nWynne Francis\n00:45:22\nI'd like to ask a question, and I can't\
+      \ see what competition I've got, I can't see anything out there. On Wednesday\
+      \ at Loyola, you gave comic tags to some of your critical opponents taken from\
+      \ Koestler [https://www.wikidata.org/wiki/Q78494], Yogis and Komisars are critics\
+      \ that are formalists and culturally and politically aware and I wondered, do\
+      \ you see the ideal critic or type of criticism as combining these two?\n \n\
+      Margaret Atwood\n00:45:51\nWell, I think that people have certain talents, you\
+      \ know, and they should exercise what talents they have, and that all kinds\
+      \ of criticism should be available to the reader. I don't think that every critic\
+      \ has to do everything, I think that would be asking a singer to be a dancer.\
+      \ \n \nWynne Francis\n00:46:08\nI remember you saying it was good to have both\
+      \ kinds, I wondered if you think they could be combined?\n \nAudience Member\
+      \ 5\n00:46:16\nIs it possible that the body of knowledge turns into the knowing\
+      \ body?\n \nMargaret Atwood\n00:46:20\nIs it possible that the body of knowledge\
+      \ turns into the knowing body? Um, I'll let you answer that. If such a person\
+      \ could do it, I'd like to see it, I've never seen anybody who could do both\
+      \ at the same time. Frye [https://www.wikidata.org/wiki/Q354256], for instance,\
+      \ does one kind in one book and then another kind in another book, but he usually\
+      \ doesn't usually do them both in the same book. I would say that Yogi-ism is\
+      \ necessary to be able to read a poem, just period pure and simple. To see what\
+      \ is happening in it. But Komasarism is necessary to place it in a larger context.\
+      \ Why not do both? Yes, I see. Back there, you\n \nAudience Member 6\n00:47:08\n\
+      Do you think that Quebec [https://www.wikidata.org/wiki/Q176] is a part of Canada?\n\
+      \ \nMargaret Atwood\n00:47:09\nOh that's such a good question.\n \nAudience\
+      \ Member 6\n00:47:11\nDo you think that a Quebecois is a Canadian?\n \nMargaret\
+      \ Atwood\n00:47:15\nI think I'll leave that to the Quebecois to decide for themselves.\
+      \ They're the people concerned. [Audience applause]. I was talking with one\
+      \ not so long ago, Marie-Claire Blais, and I asked her that question. I said,\
+      \ \u201Cwell, what do you think of yourself as? Do you think of yourself as\
+      \ a Quebecoise? or a Canadian? or a North-American, or part of Western European\
+      \ culture or a universalist?\u201D And she said, \u201CI am from Quebec\u201D\
+      . [Audience laughter]. Does that answer your question? Yes.\n \nAudience Member\
+      \  7\n00:47:58\nWhat is your opinion of the introductions in the New Canadian\
+      \ Library [https://www.wikidata.org/wiki/Q16998703] Series?\n \nMargaret Atwood\n\
+      00:48:03\nWell, they vary. [Audience laughter]. Do you mean the one? Well, I\
+      \ thought that it was, it was like a, well, the only thing I can think of is\
+      \ something fairly vulgar, um, but I don't mean that I think it was bad. I mean\
+      \ that I think it was quite a ponderous organization, being brought to bear\
+      \ on what I consider to be a fairly light piece of writing. That is, at the\
+      \ front of my book, I have a quotation from the Joy of Cooking which tells how\
+      \ to make puff pastry. And then I have you know, critical sort of, really big\
+      \ critical apparatus coming in and talking about the symbolic structuring and\
+      \ the this and the that, and I think it's nice, I'm glad to know about those\
+      \ things, but [audience laughter] it's somehow, I thought my novel was a bit\
+      \ more comic than that. If you know what I mean.\n \nAudience Member 8\n00:49:09\n\
+      Yeah, I wanted to ask a question. Yeah, I was wondering to what degree you consider\
+      \ yourself to be an ironist because you're talking about [unintelligible] irony,\
+      \ it seems to me that irony is the point I\u2019m most attracted to in your\
+      \ work anyway.\n \nMargaret Atwood\n00:49:22\nYeah, well, you can have both\
+      \ of course, as a matter of fact you usually do.\n \nAudience Member 8\n00:49:31\n\
+      You were talking about anger, and \"permit me the present tense\" kind of thing,\
+      \ seems to me that that was ironic.\n \nMargaret Atwood\n00:49:41\nAmbigu--it\
+      \ has a double meaning. But that's not always irony, I think irony has been...Well,\
+      \ somebody defined irony as a kind of literature in which the reader knows more\
+      \ about what's going on with the character than the character knows himself,\
+      \ shall we say. So, yes, of course, I think that happens in an awful lot of\
+      \ modern literature. Yes.\n \nAudience Member 9\n00:50:14\nI understand you're\
+      \ working on Survival Two?\n \nMargaret Atwood\n00:50:16\nNot working, exactly.\n\
+      \ \nAudience Member 9\n00:50:22\nI was wondering whether you could, or would\
+      \ like to elaborate on that.\n \nMargaret Atwood\n00:50:25\nYeah, okay. There\
+      \ was to have been something called Survival Two, which was to have been this\
+      \ really dynamite anthology. Which would have incorporated many of the short\
+      \ pieces mentioned in Survival, plus other ones that were appropriate and we\
+      \ did assemble this and then we had it priced as to how much it would cost for\
+      \ permissions and how much it would cost us to print it and it was just astronomically\
+      \ expensive. So we had to shelf that, and that was what Survival Two was to\
+      \ have been. Now I'll probably publish the proposed table of contents sometime\
+      \ and you can see what would have been in it. [Audience laughter]. You know,\
+      \ but a small publisher cannot afford to do this kind of thing. However, I am,\
+      \ I won't say working on because I'm working on it in the same sense that I'm\
+      \ working on my Ph.D. thesis, what I'm really doing is writing a novel. But\
+      \ I will, should I live that long, write a second edition of Survival, in which\
+      \ I hope to have five new chapters and additions to the ones that already exist.\
+      \ I think the thing about Survival that sometimes gets forgotten was that it\
+      \ was based on what was available in paperback at the time. A lot more things\
+      \ are available in paperback now, we have General Publishing coming on the scene,\
+      \ with Paper Jacks,  and New Canadian Library expanding itself and Macmillan's\
+      \ [https://www.wikidata.org/wiki/Q2108217] paperbacks expanding. So there's\
+      \ just a lot more around that you can put in and also new books have been published\
+      \ that I would like to talk about and I've discovered older ones that I didn't\
+      \ know about before. So, all of these things, plus a new introduction and maybe\
+      \ a few things at the back, I would like to do. However, I'm not quite ready\
+      \ to do it yet. I took a kind of holiday after I finished Survival One, and\
+      \ I'm still in that, it's a holiday devoted to writing other things. Yes,\n\
+      \ \nAudience Member 10\n00:52:30\nWho are your favourite poets?\n \nMargaret\
+      \ Atwood\n00:52:33\nI tend to have favourite poems, rather than favourite poets,\
+      \ but I can tell you the names of some people who've written some of my favourite\
+      \ poems. One of them is Margaret Avison [https://www.wikidata.org/wiki/Q6759152],\
+      \ one of them is P.K. Page [https://www.wikidata.org/wiki/Q2755960], they're\
+      \ poems by all kinds of people that I really like, for instance, I really like\
+      \ some of A.M. Klein's [https://www.wikidata.org/wiki/Q2778027] poems. I think\
+      \ they're just super. And more modern people, for instance, Michael Ondaatje\
+      \ [https://www.wikidata.org/wiki/Q313593], I like his work, Al Purdy [https://www.wikidata.org/wiki/Q4704621]\
+      \ I was reading in the early to middle Sixties, Doug Jones [https://www.wikidata.org/wiki/Q5203595]\
+      \ at that time. It covers a very wide range. I'm a kind of omnivorous reader,\
+      \ I'll read anything, including the backs of Cornflake boxes, so that you just\
+      \ never know, and it also changes, you know, because you read somebody for a\
+      \ while and then you've done that so you go and read somebody else.\n\nAudience\
+      \ Member 10\n00:53:31\n[Unintelligible].\n\nMargaret Atwood\n00:53:33\nOh yeah,\
+      \ I get various little magazines come floating in through the mail to me, for\
+      \ some reason. And right now, for instance, I'm reading a lot of Adrienne Rich\
+      \ [https://www.wikidata.org/wiki/Q270705], because I'm about to write a review\
+      \ of her latest book. This kind of thing, I mean it varies from month to month.\
+      \ If you ask me the same question in January the question would be different...Yeah.\n\
+      \ \nAudience Member 11\n00:54:02\n[Unintelligible] Is Surfacing more than vaguely\
+      \ autobiographical?\n \nMargaret Atwood\n00:54:11\nIt's vaguely, if you're talking\
+      \ about the plot--no. The setting, yes, and this is generally true of fiction,\
+      \ that people write from a setting that they know. They generally create characters\
+      \ out of some people that they've known plus they throw things in and invent\
+      \ them and make mosaics out of various things and the characters are fictional.\
+      \ The plot is usually a total invention. I mean, my parents are still alive\
+      \ and well, all of that. No, I have never been a paranoid schizophrenic with\
+      \ amnesia. [Audience laughter]. And as for the Edible Woman, I've never gone\
+      \ off food, but all kinds of other people have. You know, they come up to me\
+      \ and say, \u201CGee, how did you know the story of my life\u201D and \u201C\
+      that's happened to me and let me tell you it was awful, I used to throw up on\
+      \ busses\u201D. I was kind of shocked, actually, I thought it was all a big\
+      \ comic invention of my own. I see one waving at the back.\n \nAudience Member\
+      \ 12\n00:55:20\nUm, excuse me, would you say that you base your characters on\
+      \ some type of psychological background?\n \nMargaret Atwood\n00:55:25\nUm,\
+      \ I try to make them believable insofar as it will fit the plot. That is, I\
+      \ try to make what they do believable to myself, but they have to do what they\
+      \ do if you see what I mean. Yes.\n \nAudience Member 13\n00:55:46\nWould you\
+      \ say the Edible Woman is a comical invention of your own?\n \nMargaret Atwood\n\
+      00:55:49\nI said I thought it was, yeah.\n \nAudience Member 13\n00:55:51\n\
+      Well, how would you define that, as a comedy?\n \nMargaret Atwood\n00:55:54\n\
+      Oh, okay, if you wanna be technical. Um, the Edible Woman is actually an anti-comedy.\
+      \ Because a comedy is a form in which usually a young couple goes through a\
+      \ series of misadventures and blokings and gets married at the end. Now in the\
+      \ Edible Woman, a young couple goes through a series of misadventures and blokings\
+      \ and somebody else gets married at the end. [Audience laughter]. Yes. \n \n\
+      Audience Member 14\n00:56:24\nCould you tell us anything about the novel you're\
+      \ writing now?\n \nMargaret Atwood\n00:56:26\nNot a thing, that's my one superstition--well,\
+      \ it's one of my superstitions. I can't talk about work that I'm doing, it uses\
+      \ up the energy. It's true. Yeah.\n \nAudience Member 15\n00:56:41\nI read the\
+      \ Edible Woman right after reading a book by Robertson Davies [https://www.wikidata.org/wiki/Q545375],\
+      \ about [unintelligible].\n \nMargaret Atwood\n00:56:49\nOkay, the question\
+      \ is I read the Edible Woman right after reading a book by Robertson Davies,\
+      \ Fifth Business [https://www.wikidata.org/wiki/Q5447489]?\n \nAudience Member\
+      \ 15\n00:56:58\nNo, an earlier book.\n \nMargaret Atwood\n00:57:00\nManticore\
+      \ [https://www.wikidata.org/wiki/Q7750230]?\n \nAudience Member 15\n00:57:00\n\
+      It was a comedy\n \nMargaret Atwood\n00:57:01\nOh, okay.\n \nAudience Member\
+      \ 15\n00:57:02\nAbout a couple in a town [unintelligible] resolve it and they\
+      \ get married. And I wondered why he wasn't mentioned in Survival at all.\n\
+      \ \nMargaret Atwood\n00:57:15\nWell, I think probably because I wasn't doing\
+      \ humour and I wasn't doing magic. But since I am doing humour and magic in\
+      \ the next two chapters, then he will be in those. Samuel Marchbanks [https://www.wikidata.org/wiki/Q7412104]\
+      \ will be in under humour and Fifth Business and Manticore will be in under\
+      \ magic. I find the magician figure in Fifth Business very interesting from\
+      \ this particular advantage point. Why do Canadian magicians have to disguise\
+      \ themselves as foreigners in order to be thought of as magic. [Audience laughter.]\
+      \ You find this in Gwen MacEwen [https://www.wikidata.org/wiki/Q4276487] too.\
+      \ Specifically in the book called No Man.\n \nAudience Member 16\n00:58:04\n\
+      Is that a novel?\n \nMargaret Atwood\n00:58:04\nIt is a series of short stories,\
+      \ but there's sort of a central one in which you have the same pattern. Okay,\
+      \ let's have one more if there is one more. There isn't one more, there's one\
+      \ more.\n \nAudience Member 17\n00:58:22\nUm, the poems that you read tonight,\
+      \ would you consider those the best or the most significant ones from your collection,\
+      \ and if neither of those things, why did you select the ones that you read?\
+      \ The reason that I've asked that is because I've read your latest book quite\
+      \ carefully and I think that you read the, some of the best poems from it. I\
+      \ was wondering if you thought they were some of the best poems.\n \nMargaret\
+      \ Atwood\n00:58:45\nYeah. I think that one of the best things in it is section\
+      \ number three, but that consists of twenty four poems, which seem to me to\
+      \ be too long. I read some of them that I like quite a lot, yes, this is true,\
+      \ but I left out some others that I also like quite a lot because it seemed\
+      \ to me that they were too long and at this particular night anyway I felt that\
+      \ I should get through as quickly as possible because we were all stifling to\
+      \ death. Um, and with that I think that I will now end the question period and\
+      \ we can all go out and have a drink of water. \n\nAudience\n00:59:24\nApplause\
+      \ [cuts out briefly].\n \nWynne Francis\n00:59:38\nI'd just like to thank Margaret\
+      \ Atwood very much for being with us tonight--\n\nAudience\n00:59:40\nLaughter.\n\
+      \ \nEND\n00:59:46\n"
+    notes: 'Margaret Atwood reads from You Are Happy (Oxford University Press, 1974)
+      and Power Politics (Anansi, 1971). Atwood also answers audience questions about
+      her work. '
+  Contributors:
+  - dates: 1929-
+    id: 1
+    name: Beissel, Henry, 1929-
+    notes: Identity of this speaker confirmed in oral history interviews by Jason
+      Camlot with Henry Beissel (over zoom), conducted on 2020-03-27 and 2020-05-05.
+    role:
+    - id: 5ddc0be6ed9271.91106328
+      value: Presenter
+    url: http://viaf.org/viaf/5489879/#Beissel,_Henry
+  - dates: 1918-2000
+    id: 2
+    name: Francis, Wynne
+    role:
+    - id: 60749d10464745.33536784
+      value: Series organizer
+    - id: 60749d12604dd0.05898139
+      value: Presenter
+    url: http://viaf.org/viaf/77926194
+  - dates: 1934-
+    id: 3
+    name: 'Fink, Howard, '
+    role:
+    - id: 5ddc0c658edc91.32504737
+      value: Series organizer
+    - id: 60749d7406dcd0.79818065
+      value: Speaker
+    url: http://viaf.org/viaf/6332801
+  Creators:
+  - dates: 1939-
+    id: 1
+    name: Atwood, Margaret
+    notes: "Internationally acclaimed novelist, poet, critic and activist Margaret\
+      \ Atwood was born in Ottawa, Ontario, November 18, 1939. She lived in Ottawa\
+      \ until 1946, when her family settled in Leaside, a suburb of Toronto. Atwood\
+      \ entered Victoria College, University of Toronto, graduating with honours in\
+      \ 1961. Her first published collection of short stories was Double Persephone\
+      \ (Hawkshead Press, 1961). By 1962 she had received her MA in English from Radcliffe\
+      \ College in the United States, working on further graduate work at Harvard\
+      \ University between 1962-3 and in 1965-7. Atwood published her second collection,\
+      \ The Circle Game (Anansi, 1966), which won the Governor General Award for Poetry.\
+      \ She wrote articles and reviews for Alphabet, Canadian Literature and Poetry\
+      \ among other publications, and poems for Kayak, Quarry and the Tamarack Review.\
+      \ Poems published in her book The Animals in That Country (Oxford University\
+      \ Press, 1968) won first prize in Canada\u2019s 1967 Centennial Commission poetry\
+      \ competition. In 1970, she published three books, Procedures for Underground\
+      \ (Oxford University Press), Time, and The Journals of Susanna Moodie (Oxford\
+      \ University Press). Between 1971 and 1973, Atwood worked as an editor and on\
+      \ the board of directors for the House of Anansi press in Toronto, which in\
+      \ 1972 published Power Politics. Upon the discovery at Harvard that there was\
+      \ no published critical study of Canadian literature, she herself wrote and\
+      \ published Survival: A Thematic Guide to Canadian Literature (Anansi, 1971),\
+      \ which created a stir of controversy, but by 1982 it had sold more than 85,000\
+      \ copies. Since 1973, she has lived with novelist and activist Graeme Gibson,\
+      \ producing one daughter, Eleanor Jess in 1967. Atwood taught and lectured at\
+      \ several Universities across Canada, the US and Australia, including University\
+      \ of British Columbia, University of Alberta, Sir George Williams University\
+      \ (now Concordia) (1967-68) and at York University, Toronto. A selection of\
+      \ her publications include Surfacing (Simon & Schuster, 1972), You Are Happy\
+      \ (Harper & Row, 1974), Selected Poems (Oxford University Press) in 1976, Two-Headed\
+      \ Poems (Simon & Schuster, 1978), True Stories (Oxford University Press, 1981)\
+      \ and Second Words (Anansi, 1982). Her 1985 novel, The Handmaid\u2019s Tale\
+      \ (McClelland & Stewart) became one of her most popular and critically acclaimed\
+      \ works. In 1986 she was appointed the Berg Chair at New York University, as\
+      \ well as serving as writer-in-residence at several other Universities. She\
+      \ co-founded and served as chair to the Writer\u2019s Union of Canada in 1982-3,\
+      \ and served as president of the Canadian Centre of International PEN from 1984-6.\
+      \ She has subsequently published dozens of books, including Cat\u2019s Eye (McClelland\
+      \ & Stewart, 1988), The Robber Bride (Doubleday, 1993), Alias Grace (Nan A.\
+      \ Talese, 1996), The Blind Assassin (Nan A. Talese, 2000), Oryx and Crake (2003),\
+      \ The Penelopiad (Canongate, 2005) and The Tent (Bloomsbury, 2006). Along with\
+      \ many other publications of her critical essays, Curious Pursuits: Occasional\
+      \ Writing 1970-2005 (Verago) came out in 2005. Her many prizes and honours include\
+      \ the Booker Prize, the E.J. Pratt Medal (1961), The Radcliffe Medal (1980),\
+      \ the Commonwealth Writers Prize (1992), and she is a Companion of the Order\
+      \ of Canada. Atwood continues to work as spokesperson on behalf of human rights\
+      \ and the environment."
+    role:
+    - id: 5ddc0b96a16d81.95004399
+      value: Author
+    - id: 5f638b9366db06.03076524
+      value: Performer
+    - id: 60749cdc2c1f81.53977584
+      value: Speaker
+    url: http://viaf.org/viaf/109322990
+  Dates:
+  - date: 1974 10 18
+    id: 1
+    notes: Date written on the front of the tape's box. This date was confirmed in.
+      the Oct 18, 1974 issue of The Georgian.
+    source: Accompanying Material
+    type: Performance Date
+  Digital_File_Description:
+  - content_type: Sound Recording
+    contents: "margaret_atwood_i006-11-008.mp3\n\nHenry Beissel\n00:00:00\nOne moment...\
+      \ problem that we have here at Sir George [https://www.wikidata.org/wiki/Q326342].\
+      \ We did try to get a larger hall but it was impossible. To accommodate the\
+      \ overflow, we have set up loudspeakers in the little gallery here, Howard,\
+      \ and in the other one too?\n \nHoward Fink\n00:00:21\nOutside.\n \nHenry Beissel\n\
+      00:00:22\nOutside, there are loudspeakers. So please don't all crowd into the\
+      \ room. If you are going to lean against the paintings, we shall never be able\
+      \ to get this room again for poetry readings. Because this, this is a gallery\
+      \ which belongs to the Fine Arts department, we had great difficulty getting\
+      \ it, these paintings are very precious, particularly to the artists themselves\
+      \ [audience laughter]. I would ask you please to stay away from the paintings.\
+      \ That must have been the artist [audience laughter]. We are also waiting for\
+      \ the arrival of someone else, so please be patient. Howard--[audience laughter]\
+      \ can you ask the security people to turn on the cooling system, the hall is\
+      \ going to be too hot.\n \nUnknown\n00:01:22\nAmbient Sound [voices].\n \nHenry\
+      \ Beissel\n00:01:25\nWe may get 927.\n \nMargaret Atwood\n00:01:30\nWhat do\
+      \ you mean, we may, I think they're also--okay. What would you like to do? Let\
+      \ us stay here or move?\n \nAudience\n00:01:41\nStay here.\n \nMargaret Atwood\n\
+      00:01:44\nOkay, with the people, there are some people who are at the back of\
+      \ the door, there is some space up here at the front if you'd like to come up.\n\
+      \ \nHenry Beissel\n00:01:54\nNo more than ten.\n \nMargaret Atwood\n00:01:58\n\
+      About ten. It'll make more room at the back too...If everybody on the chairs\
+      \ would shift over this way, um, and sit on, sort of as if it were a bench,\
+      \ then some more people can sit on the edges there. Or just move the chairs\
+      \ all that way. Move the rows forward. They're all shifting over anyway. Could\
+      \ you all move your chairs forward to make the rows as close together as possible.\
+      \ Okay, it's alright. \n\nUnknown\n00:03:17\nAmbient Sound [voices].\n\nMargaret\
+      \ Atwood\n00:04:41\nThere are these uhh--woohoo--there are these speakers outside\
+      \ and you might be more comfortable if you went out and listened over the speakers,\
+      \ some of the people are really jammed in there. I don't see any reason why\
+      \ this thing should resemble a steam bath, for all of us. If you're--what? what?...I\
+      \ don't think I can, what is it that they do? [Audience laughter].\n \nWynne\
+      \ Francis\n00:05:19\n[Laughter]. Miss Atwood [https://www.wikidata.org/wiki/Q183492]\
+      \ has just upstaged the introducer. Good evening ladies and gentlemen. It's\
+      \ not often that an artist excels in two medium such as poetry and fiction as\
+      \ our guest tonight does. Miss Atwood's reputation as a superior poet was established\
+      \ in the 60's with her first collections, The Circle Game [https://www.wikidata.org/wiki/Q7723073]\
+      \ and The Animals in that Country [https://www.wikidata.org/wiki/Q7713834].\
+      \ And while continuing to write fine poetry, six major collections to date,\
+      \ she's given  us two novels in the last five years, The Edible Woman [https://www.wikidata.org/wiki/Q7731579]\
+      \ and Surfacing. With the second novel, published late in 1972, within a few\
+      \ months of a controversial work of criticism, Margaret Atwood became one of\
+      \ Canada's [https://www.wikidata.org/wiki/Q16] best known literary artists.\
+      \ The hypothesis of Survival, a study of patterns in Canadian lit is that Canadians\
+      \ see themselves as victims. I was remind of Survival recently when I came across\
+      \ a nineteenth-century curiosity written by one John McTaggart [https://www.wikidata.org/wiki/Q463553].\
+      \ It was a book published in London [https://www.wikidata.org/wiki/Q84] in 19--\
+      \ excuse me--1829. McTaggart wrote \"There's a melancholy which is peculiar\
+      \ to Canadians which must be combatted. People who labor under it must be encouraged,\
+      \ the soothing language, good treatment and now and then as circumstances require,\
+      \ a little assistance gratis as a stimulant.\" McTaggart's third point about\
+      \ the helpful effects of a little assistance as a recent theory has been taken\
+      \ up by the Canada Council [https://www.wikidata.org/wiki/Q2993809], to whom\
+      \ we are in part indebted for her appearance tonight. Margaret Atwood's work\
+      \ constitutes an exploration of what it means to be a Canadian, to be a woman\
+      \ and to be a human being. She writes about our totems, our tapestry of manners,\
+      \ our progressive insanities. She taught at Sir George in 67-68, and it's a\
+      \ great pleasure to have her return to us tonight. After her reading, she'll\
+      \ be open to questions from the audience. Ladies and gentlemen, Margaret Atwood.\n\
+      \nAudience\n00:07:27\nApplause [cuts out briefly].\n\nMargaret Atwood\n00:07:38\n\
+      Let's see now, if the mic starts to get funny, let me know...Too loud?...Not\
+      \ too loud, I'm afraid it isn't a very good mic and also I'm afraid I'm going\
+      \ to have to hold it the whole time which is a bore...I don't think it'll work\
+      \ very well, is that better? Does that work? Higher? Lower? Okay, how's that?\
+      \ Okay, I'm going to read entirely from my new book which is called \"This is\"\
+      --oh, what is it called? [audience laughter]. It's called You Are Happy. Somebody\
+      \ who has been photographing me says that a friend of hers was in a bookstore\
+      \ and picked out this book and thought at first that this was one of these \"\
+      I'm Okay, You're Okay\" books. Until I saw who wrote it. [Audience laughter].\
+      \ But it has a happy ending, you'll be pleased to know. And I'm going to begin\
+      \ at the beginning and end at the end. Skipping portions along the way. I'm\
+      \ also going to make this reading fairly short because we are all in this rather\
+      \ constricted situation. I used to tell people when people in the States [https://www.wikidata.org/wiki/Q30]\
+      \ used to ask me \u201Cdo you live in an igloo\u201D and other questions like\
+      \ that, I used to think to myself that being a Canadian was sort of like living\
+      \ in a chicken coop in the middle of the desert. That everybody was all together\
+      \ in one place but there are these huge spaces around. I wish that  we had been\
+      \ provided with one of them. [Audience laughter]. I have a chicken coop, and\
+      \ you're nicer. But there are more of you. I think we will all have to be very,\
+      \ very patient, unlike the chickens. I'm going to begin by reading a poem called\
+      \ \"Newsreel: Man and Firing Squad\".\n \nMargaret Atwood\n00:10:04\nReads \"\
+      Newsreel: Man and Firing Squad\" from You Are Happy.\n \nMargaret Atwood\n00:11:42\n\
+      Reads \"Useless\" from You Are Happy.\n \nMargaret Atwood\n00:12:35\nThis is--the\
+      \ image in this next poem comes from, begins with the fact that I have a sheep\
+      \ and one of them died. The poem is called \"November\".\n \nMargaret Atwood\n\
+      00:12:48\nReads \"November\" from You Are Happy.\n \nMargaret Atwood\n00:13:52\n\
+      Reads \"Repent\" from You Are Happy.\n \nMargaret Atwood\n00:14:47\n\"Tricks\
+      \ with Mirrors\". How are you doing? Is it hot and steamy? Has anybody died\
+      \ yet?\n \nMargaret Atwood\n00:15:05\nReads \"Tricks with Mirrors\" from You\
+      \ Are Happy.\n \nMargaret Atwood\n00:17:45\nThis is the title poem, \"You Are\
+      \ Happy\".\n \nMargaret Atwood\n00:17:50\nReads \"You are Happy\" from You Are\
+      \ Happy.\n \nMargaret Atwood\n00:18:48\nReads \"First Prayer\" from You Are\
+      \ Happy.\n \nMargaret Atwood\n00:20:25\n\"Is / Not: 1\". Oh boy, is it ever\
+      \ hot in here. I can't stand it. Light. I wonder if we could--well, then I can't\
+      \ see, you see. I wonder if we could turn off--would it be better if we turn\
+      \ off those lights that are grilling you over there...I could what?...Where's\
+      \ the light switch anyway? Howard, turn off the lights?...Well, maybe in a few\
+      \ minutes the lights will go off. Where did\u2026\n\nUnknown\n00:21:36\n[Cut\
+      \ or edit made in tape. Unknown amount of time elapsed]. \n\nMargaret Atwood\n\
+      00:21:37\nHooray, wonderful. Actually, there's a light under here. It's like\
+      \ the Saturday movies [audience laughter]. No, I can read with this, yeah. Maybe\
+      \ I'll just read a little something else here, because it's the Saturday Movies.\n\
+      \ \nMargaret Atwood\n00:22:18\nReads [\"You take my hand\" from Power Politics;\
+      \ audience laughter throughout].\n \nMargaret Atwood\n00:23:13\nAnd since we\
+      \ were talking about the war between Superman [https://www.wikidata.org/wiki/Q79015]\
+      \ and Captain Marvel [https://www.wikidata.org/wiki/Q534153] at dinner, my favourite\
+      \ was Plastic Man [https://www.wikidata.org/wiki/Q746838], but that was an esoteric\
+      \ taste. I'll read this one.\n \nMargaret Atwood\n00:23:28\nReads \"They Eat\
+      \ Out\" [from Power Politics].\n \nMargaret Atwood\n00:24:44\nI go to--I can't\
+      \ resist this. This is from the new book, it's called \"Siren Song\". Students\
+      \ of Seventeenth Century Literature are always asking themselves and each other,\
+      \ what song the sirens sang, and this is the ultimate answer.\n \nMargaret Atwood\n\
+      00:25:06\nReads \"Siren Song\" from You Are Happy.\n \nMargaret Atwood\n00:26:12\n\
+      The imminent critic, Allen Pearson, who was once known when he lived in Montreal\
+      \ [https://www.wikidata.org/wiki/Q340] as the Montreal Poet, now that he lives\
+      \ in Toronto [https://www.wikidata.org/wiki/Q172], he's probably known as the\
+      \ Toronto Poet, says the following: \"Siren Song tells how boring it is for\
+      \ a woman to be obliged to attract men by appealing to them for help\". [Audience\
+      \ laughter]. Um, since I'm on the subject of people in capes and costumes, I'll\
+      \ read...\n \nUnknown\n00:26:56\n[Cut or edit made in tape. Unknown amount of\
+      \ time elapsed].\n\nAnnotation\n00:26:57\nReads [untitled poem from the \u201C\
+      Circle/Mud Poems\u201D section in You Are Happy].\n \nMargaret Atwood\n00:28:20\n\
+      Reads \"Is / Not\" from You Are Happy.\n \nMargaret Atwood\n00:30:37\nI think\
+      \ I'd better read just three more poems, before we all die. The first one is\
+      \ called \"There is Only One of Everything\".\n \nMargaret Atwood\n00:30:54\n\
+      Reads \"There is Only One of Everything\" from You Are Happy.\n \nMargaret Atwood\n\
+      00:32:30\nReads \"Late August\" from You Are Happy.\n \nMargaret Atwood\n00:33:26\n\
+      This is the last poem, called \"Book of Ancestors\".\n \nMargaret Atwood\n00:33:33\n\
+      Reads \"Book of Ancestors\" from You Are Happy. \n \nAudience\n00:36:31\nApplause\
+      \ [cuts out briefly].\n\nWynne Francis\n00:36:47\nThank you, it's really not\
+      \ so hot if you sit still. Miss Atwood is prepared to discuss, for a little\
+      \ while.\n \nMargaret Atwood\n00:37:04\nIf you would like to, uh, I can't see\
+      \ a thing of course, I can sort of see hands if you stick them up and wave them\
+      \ around. Would that be better than turning back on the lights which I'd prefer\
+      \ not to do?\n \nWynne Francis\n00:37:22\nThere's no way we can get mics in\
+      \ the audience, so please speak loudly.\n \nMargaret Atwood\n00:37:23\nI see\
+      \ a hand.\n \nAudience Member 1\n00:37:28\nHow did your nickname of a witch\
+      \ get originated?\n \nMargaret Atwood\n00:37:30\nHow did my nickname of a witch?\
+      \ Are you referring to the speech I gave the other night at Loyola? Oh, it's,\
+      \ I was talking about a couple of reviews, that seemed to credit me with having\
+      \ these supernatural powers, you know, the ability to hypnotize my readers and\
+      \ things like that, and what I was saying was that in fact I don't in fact possess\
+      \ the powers of hypnotism or I'd use them on my bank manager and be quite rich.\
+      \ Um, I was talking about a pattern that seems to crop up from time to time\
+      \ in a certain kind of review usually written by men. [Audience laughter]. I\
+      \ heard that there were a couple of people in the audience at Loyola who before\
+      \ the speech, were convinced that I was a witch and that I was going to talk\
+      \ about witchcraft, and when I said that I wasn't one, they left. [Audience\
+      \ laughter]. You see, if I were a witch, I wouldn't be able to wear the cross.\
+      \ So that's how you can tell I'm not. Wards off vampires. Um, yes?\n \nAudience\
+      \ Member 2\n00:38:54\nUm, [unintelligible] and as well as the Edible Woman,\
+      \ I seem to get this idea of an emergence from greyness, or darkness and I was\
+      \ wondering if it's through this emergence from greyness that you have any reference\
+      \ to Blake [https://www.wikidata.org/wiki/Q41513] in his emergence from chaos.\n\
+      \ \nMargaret Atwood\n00:39:17\nI'll be very flattered, if I did. I'm afraid\
+      \ I suffer by the comparison. I think that you're right in spotting it, I think\
+      \ I would say that it's more like this, that if you want to think in terms of\
+      \ colour, that you start with a grey, and then you go down. Down into, well,\
+      \ it depends on the poem or the book or whatever of what's happening in your\
+      \ life. And, but you have to go down before you come up again otherwise you\
+      \ stay just in the grey part. If you want a real pattern for this, it's Dante's\
+      \ [https://www.wikidata.org/wiki/Q1067] Inferno [https://www.wikidata.org/wiki/Q4509219],\
+      \ where the man starts in a wandering wood, you know he starts in a kind of\
+      \ state of being lost, and then he goes down into hell. The further down he\
+      \ goes the more tortured souls he sees, but when he gets right to the bottom\
+      \ he finds that he's going up again. And then he comes out the other side.\n\
+      \ \nAudience Member 2\n00:40:19\nYeah, but, in this other side-ness in the Edible\
+      \ Woman you come up through colours, a very [unintelligible] of colours and\
+      \ I was wondering if this is the complete emergence of man?\n \nMargaret Atwood\n\
+      00:40:29\nNot complete--I would say no, no beginning.\n \nAudience Member 2\n\
+      00:40:32\n[Unintelligible] complete--into his universal aspect, but into an\
+      \ emergence of man. Into the colours of life.\n \nMargaret Atwood\n00:40:39\n\
+      Your choice of the word 'man' is interesting. Since the heroine is a woman.\
+      \ [Audience laughter and applause]. Um, I think you have the pattern right.\
+      \ I wouldn't like to attach any sort of universal meaning to it.\n \nAudience\
+      \ Member 2\n00:40:56\nNo I'm not attaching a universal meaning, I'm attaching\
+      \ more or less a universal meaning to the colour of darkness or greyness.\n\
+      \ \nMargaret Atwood\n00:41:04\nNo, that's right, you're correct. Yes.\n \nAudience\
+      \ Member 2\n00:41:07\nI'm not trying to express a universal meaning into these\
+      \ colours, this is where you're taking it wrong.\n \nMargaret Atwood\n00:41:14\n\
+      Well, I'm not too sure what we're talking about  to tell you the truth. You've\
+      \ spotted a correct pattern and I'm not too sure how one interprets it because\
+      \ I don't like to be the critic of  my own work in a way if you know what I\
+      \ mean. Yes.\n \nAudience Member 3\n00:41:34\nI know you're writing a screenplay\
+      \ for [unintelligible]. Will it ever become a film?\n \nMargaret Atwood\n00:41:39\n\
+      Will it ever? Let's see now, I finished it at the end of July. Now, what is--the\
+      \ stages of making a film are these: first somebody takes out an option on it,\
+      \ which means they pay you X dollars to have the sole right to try to make the\
+      \ movie for a certain period of time. If they fail to make it to renew the option\
+      \ or to require the rights at the end of that period, you get it back and you\
+      \ can then sell it to anybody else or back to them if you want. That's different\
+      \ from buying the rights which means they've got it. And you can't get it back.\
+      \ An option has been taken out, a script has been written. They are now doing\
+      \ whatever it is they do, who knows. To try to put together what is called a\
+      \ package, that is, they try to interest a director or they pick out a director\
+      \ and they try to put a director together with a script together with some money.\
+      \ And that's all going on, I don't know what's happening with it because they\
+      \ don't tell. Yes.\n \nAudience Member 4\n00:42:42\nAre those people American\
+      \ or Canadian?\n \nMargaret Atwood\n00:42:47\nThese people are. [Audience laughter].\
+      \ Once upon a time there was an English Canadian film industry. Not very hard.\
+      \ I mean it's trying very hard but not many results are being had. And I wanted\
+      \ very much to make Surfacing in Canada with Canadian everything, but I was\
+      \ about two years too late. And also Canadians are quite timmerus about this\
+      \ book because they said \u201Cwell, it'll never be able to sell a film in the\
+      \ States\u201D because of all that strange American symbolism in it. They--the\
+      \ two people I'm working with are two American independent producers, not to\
+      \ be confused with MGM [https://www.wikidata.org/wiki/Q179200], who want to\
+      \ make the book as it is, that is, they like the book, they want to be faithful\
+      \ to it, they don't want to transport it to Maine [https://www.wikidata.org/wiki/Q724]\
+      \ or wherever and make it into an American film, which of course you couldn't\
+      \ do without ruining the symbolic pattern. They want to make it in Canada, they\
+      \ want to put in all that stuff because they say \u201Cwow, dynamite\u201D.\
+      \ [Audience laughter]. They're not worried about selling it in the States. So\
+      \ that's how we're proceeding right now and we have not yet had a falling out\
+      \ on any of the crucial matters such as what's in the screenplay. And so that's\
+      \ been fine. They would like to make it here. And what stage they're at right\
+      \ now I don't know. Now if they don't put it together, then I get it back and\
+      \ then I have another go. And I'll try it \u2018round Canada again, once more,\
+      \ and I'll probably with the same results--\n \nAudience Member 4\n00:44:26\n\
+      You have tried?\n \nMargaret Atwood\n00:44:30\nOh yes, everybody tries. I've\
+      \ written four or five screenplays, none of them have been made. They've all\
+      \ been for Canadians. One thing has happened, I got one television play done,\
+      \ but of course everything you do for the CBC [https://www.wikidata.org/wiki/Q461761]\
+      \ pretty well gets done. [Audience laughter]. As you know. I wrote a screenplay\
+      \ for Edible Woman that didn't get done. I wrote one for Marie-Claire Blais\
+      \ [https://www.wikidata.org/wiki/Q298358], Mad Shadows, we had high hopes for\
+      \ that, that was a Canadian director, Canadian producer all the rest of it.\
+      \ No deal. Film development corporations said it wasn't commercial enough. I\
+      \ mean, you don't go outside before you've been through it for a while. It's\
+      \ a problem that novelists used to face when trying to get their novels published\
+      \ here.\n \nWynne Francis\n00:45:22\nI'd like to ask a question, and I can't\
+      \ see what competition I've got, I can't see anything out there. On Wednesday\
+      \ at Loyola, you gave comic tags to some of your critical opponents taken from\
+      \ Koestler [https://www.wikidata.org/wiki/Q78494], Yogis and Komisars are critics\
+      \ that are formalists and culturally and politically aware and I wondered, do\
+      \ you see the ideal critic or type of criticism as combining these two?\n \n\
+      Margaret Atwood\n00:45:51\nWell, I think that people have certain talents, you\
+      \ know, and they should exercise what talents they have, and that all kinds\
+      \ of criticism should be available to the reader. I don't think that every critic\
+      \ has to do everything, I think that would be asking a singer to be a dancer.\
+      \ \n \nWynne Francis\n00:46:08\nI remember you saying it was good to have both\
+      \ kinds, I wondered if you think they could be combined?\n \nAudience Member\
+      \ 5\n00:46:16\nIs it possible that the body of knowledge turns into the knowing\
+      \ body?\n \nMargaret Atwood\n00:46:20\nIs it possible that the body of knowledge\
+      \ turns into the knowing body? Um, I'll let you answer that. If such a person\
+      \ could do it, I'd like to see it, I've never seen anybody who could do both\
+      \ at the same time. Frye [https://www.wikidata.org/wiki/Q354256], for instance,\
+      \ does one kind in one book and then another kind in another book, but he usually\
+      \ doesn't usually do them both in the same book. I would say that Yogi-ism is\
+      \ necessary to be able to read a poem, just period pure and simple. To see what\
+      \ is happening in it. But Komasarism is necessary to place it in a larger context.\
+      \ Why not do both? Yes, I see. Back there, you\n \nAudience Member 6\n00:47:08\n\
+      Do you think that Quebec [https://www.wikidata.org/wiki/Q176] is a part of Canada?\n\
+      \ \nMargaret Atwood\n00:47:09\nOh that's such a good question.\n \nAudience\
+      \ Member 6\n00:47:11\nDo you think that a Quebecois is a Canadian?\n \nMargaret\
+      \ Atwood\n00:47:15\nI think I'll leave that to the Quebecois to decide for themselves.\
+      \ They're the people concerned. [Audience applause]. I was talking with one\
+      \ not so long ago, Marie-Claire Blais, and I asked her that question. I said,\
+      \ \u201Cwell, what do you think of yourself as? Do you think of yourself as\
+      \ a Quebecoise? or a Canadian? or a North-American, or part of Western European\
+      \ culture or a universalist?\u201D And she said, \u201CI am from Quebec\u201D\
+      . [Audience laughter]. Does that answer your question? Yes.\n \nAudience Member\
+      \  7\n00:47:58\nWhat is your opinion of the introductions in the New Canadian\
+      \ Library [https://www.wikidata.org/wiki/Q16998703] Series?\n \nMargaret Atwood\n\
+      00:48:03\nWell, they vary. [Audience laughter]. Do you mean the one? Well, I\
+      \ thought that it was, it was like a, well, the only thing I can think of is\
+      \ something fairly vulgar, um, but I don't mean that I think it was bad. I mean\
+      \ that I think it was quite a ponderous organization, being brought to bear\
+      \ on what I consider to be a fairly light piece of writing. That is, at the\
+      \ front of my book, I have a quotation from the Joy of Cooking which tells how\
+      \ to make puff pastry. And then I have you know, critical sort of, really big\
+      \ critical apparatus coming in and talking about the symbolic structuring and\
+      \ the this and the that, and I think it's nice, I'm glad to know about those\
+      \ things, but [audience laughter] it's somehow, I thought my novel was a bit\
+      \ more comic than that. If you know what I mean.\n \nAudience Member 8\n00:49:09\n\
+      Yeah, I wanted to ask a question. Yeah, I was wondering to what degree you consider\
+      \ yourself to be an ironist because you're talking about [unintelligible] irony,\
+      \ it seems to me that irony is the point I\u2019m most attracted to in your\
+      \ work anyway.\n \nMargaret Atwood\n00:49:22\nYeah, well, you can have both\
+      \ of course, as a matter of fact you usually do.\n \nAudience Member 8\n00:49:31\n\
+      You were talking about anger, and \"permit me the present tense\" kind of thing,\
+      \ seems to me that that was ironic.\n \nMargaret Atwood\n00:49:41\nAmbigu--it\
+      \ has a double meaning. But that's not always irony, I think irony has been...Well,\
+      \ somebody defined irony as a kind of literature in which the reader knows more\
+      \ about what's going on with the character than the character knows himself,\
+      \ shall we say. So, yes, of course, I think that happens in an awful lot of\
+      \ modern literature. Yes.\n \nAudience Member 9\n00:50:14\nI understand you're\
+      \ working on Survival Two?\n \nMargaret Atwood\n00:50:16\nNot working, exactly.\n\
+      \ \nAudience Member 9\n00:50:22\nI was wondering whether you could, or would\
+      \ like to elaborate on that.\n \nMargaret Atwood\n00:50:25\nYeah, okay. There\
+      \ was to have been something called Survival Two, which was to have been this\
+      \ really dynamite anthology. Which would have incorporated many of the short\
+      \ pieces mentioned in Survival, plus other ones that were appropriate and we\
+      \ did assemble this and then we had it priced as to how much it would cost for\
+      \ permissions and how much it would cost us to print it and it was just astronomically\
+      \ expensive. So we had to shelf that, and that was what Survival Two was to\
+      \ have been. Now I'll probably publish the proposed table of contents sometime\
+      \ and you can see what would have been in it. [Audience laughter]. You know,\
+      \ but a small publisher cannot afford to do this kind of thing. However, I am,\
+      \ I won't say working on because I'm working on it in the same sense that I'm\
+      \ working on my Ph.D. thesis, what I'm really doing is writing a novel. But\
+      \ I will, should I live that long, write a second edition of Survival, in which\
+      \ I hope to have five new chapters and additions to the ones that already exist.\
+      \ I think the thing about Survival that sometimes gets forgotten was that it\
+      \ was based on what was available in paperback at the time. A lot more things\
+      \ are available in paperback now, we have General Publishing coming on the scene,\
+      \ with Paper Jacks,  and New Canadian Library expanding itself and Macmillan's\
+      \ [https://www.wikidata.org/wiki/Q2108217] paperbacks expanding. So there's\
+      \ just a lot more around that you can put in and also new books have been published\
+      \ that I would like to talk about and I've discovered older ones that I didn't\
+      \ know about before. So, all of these things, plus a new introduction and maybe\
+      \ a few things at the back, I would like to do. However, I'm not quite ready\
+      \ to do it yet. I took a kind of holiday after I finished Survival One, and\
+      \ I'm still in that, it's a holiday devoted to writing other things. Yes,\n\
+      \ \nAudience Member 10\n00:52:30\nWho are your favourite poets?\n \nMargaret\
+      \ Atwood\n00:52:33\nI tend to have favourite poems, rather than favourite poets,\
+      \ but I can tell you the names of some people who've written some of my favourite\
+      \ poems. One of them is Margaret Avison [https://www.wikidata.org/wiki/Q6759152],\
+      \ one of them is P.K. Page [https://www.wikidata.org/wiki/Q2755960], they're\
+      \ poems by all kinds of people that I really like, for instance, I really like\
+      \ some of A.M. Klein's [https://www.wikidata.org/wiki/Q2778027] poems. I think\
+      \ they're just super. And more modern people, for instance, Michael Ondaatje\
+      \ [https://www.wikidata.org/wiki/Q313593], I like his work, Al Purdy [https://www.wikidata.org/wiki/Q4704621]\
+      \ I was reading in the early to middle Sixties, Doug Jones [https://www.wikidata.org/wiki/Q5203595]\
+      \ at that time. It covers a very wide range. I'm a kind of omnivorous reader,\
+      \ I'll read anything, including the backs of Cornflake boxes, so that you just\
+      \ never know, and it also changes, you know, because you read somebody for a\
+      \ while and then you've done that so you go and read somebody else.\n\nAudience\
+      \ Member 10\n00:53:31\n[Unintelligible].\n\nMargaret Atwood\n00:53:33\nOh yeah,\
+      \ I get various little magazines come floating in through the mail to me, for\
+      \ some reason. And right now, for instance, I'm reading a lot of Adrienne Rich\
+      \ [https://www.wikidata.org/wiki/Q270705], because I'm about to write a review\
+      \ of her latest book. This kind of thing, I mean it varies from month to month.\
+      \ If you ask me the same question in January the question would be different...Yeah.\n\
+      \ \nAudience Member 11\n00:54:02\n[Unintelligible] Is Surfacing more than vaguely\
+      \ autobiographical?\n \nMargaret Atwood\n00:54:11\nIt's vaguely, if you're talking\
+      \ about the plot--no. The setting, yes, and this is generally true of fiction,\
+      \ that people write from a setting that they know. They generally create characters\
+      \ out of some people that they've known plus they throw things in and invent\
+      \ them and make mosaics out of various things and the characters are fictional.\
+      \ The plot is usually a total invention. I mean, my parents are still alive\
+      \ and well, all of that. No, I have never been a paranoid schizophrenic with\
+      \ amnesia. [Audience laughter]. And as for the Edible Woman, I've never gone\
+      \ off food, but all kinds of other people have. You know, they come up to me\
+      \ and say, \u201CGee, how did you know the story of my life\u201D and \u201C\
+      that's happened to me and let me tell you it was awful, I used to throw up on\
+      \ busses\u201D. I was kind of shocked, actually, I thought it was all a big\
+      \ comic invention of my own. I see one waving at the back.\n \nAudience Member\
+      \ 12\n00:55:20\nUm, excuse me, would you say that you base your characters on\
+      \ some type of psychological background?\n \nMargaret Atwood\n00:55:25\nUm,\
+      \ I try to make them believable insofar as it will fit the plot. That is, I\
+      \ try to make what they do believable to myself, but they have to do what they\
+      \ do if you see what I mean. Yes.\n \nAudience Member 13\n00:55:46\nWould you\
+      \ say the Edible Woman is a comical invention of your own?\n \nMargaret Atwood\n\
+      00:55:49\nI said I thought it was, yeah.\n \nAudience Member 13\n00:55:51\n\
+      Well, how would you define that, as a comedy?\n \nMargaret Atwood\n00:55:54\n\
+      Oh, okay, if you wanna be technical. Um, the Edible Woman is actually an anti-comedy.\
+      \ Because a comedy is a form in which usually a young couple goes through a\
+      \ series of misadventures and blokings and gets married at the end. Now in the\
+      \ Edible Woman, a young couple goes through a series of misadventures and blokings\
+      \ and somebody else gets married at the end. [Audience laughter]. Yes. \n \n\
+      Audience Member 14\n00:56:24\nCould you tell us anything about the novel you're\
+      \ writing now?\n \nMargaret Atwood\n00:56:26\nNot a thing, that's my one superstition--well,\
+      \ it's one of my superstitions. I can't talk about work that I'm doing, it uses\
+      \ up the energy. It's true. Yeah.\n \nAudience Member 15\n00:56:41\nI read the\
+      \ Edible Woman right after reading a book by Robertson Davies [https://www.wikidata.org/wiki/Q545375],\
+      \ about [unintelligible].\n \nMargaret Atwood\n00:56:49\nOkay, the question\
+      \ is I read the Edible Woman right after reading a book by Robertson Davies,\
+      \ Fifth Business [https://www.wikidata.org/wiki/Q5447489]?\n \nAudience Member\
+      \ 15\n00:56:58\nNo, an earlier book.\n \nMargaret Atwood\n00:57:00\nManticore\
+      \ [https://www.wikidata.org/wiki/Q7750230]?\n \nAudience Member 15\n00:57:00\n\
+      It was a comedy\n \nMargaret Atwood\n00:57:01\nOh, okay.\n \nAudience Member\
+      \ 15\n00:57:02\nAbout a couple in a town [unintelligible] resolve it and they\
+      \ get married. And I wondered why he wasn't mentioned in Survival at all.\n\
+      \ \nMargaret Atwood\n00:57:15\nWell, I think probably because I wasn't doing\
+      \ humour and I wasn't doing magic. But since I am doing humour and magic in\
+      \ the next two chapters, then he will be in those. Samuel Marchbanks [https://www.wikidata.org/wiki/Q7412104]\
+      \ will be in under humour and Fifth Business and Manticore will be in under\
+      \ magic. I find the magician figure in Fifth Business very interesting from\
+      \ this particular advantage point. Why do Canadian magicians have to disguise\
+      \ themselves as foreigners in order to be thought of as magic. [Audience laughter.]\
+      \ You find this in Gwen MacEwen [https://www.wikidata.org/wiki/Q4276487] too.\
+      \ Specifically in the book called No Man.\n \nAudience Member 16\n00:58:04\n\
+      Is that a novel?\n \nMargaret Atwood\n00:58:04\nIt is a series of short stories,\
+      \ but there's sort of a central one in which you have the same pattern. Okay,\
+      \ let's have one more if there is one more. There isn't one more, there's one\
+      \ more.\n \nAudience Member 17\n00:58:22\nUm, the poems that you read tonight,\
+      \ would you consider those the best or the most significant ones from your collection,\
+      \ and if neither of those things, why did you select the ones that you read?\
+      \ The reason that I've asked that is because I've read your latest book quite\
+      \ carefully and I think that you read the, some of the best poems from it. I\
+      \ was wondering if you thought they were some of the best poems.\n \nMargaret\
+      \ Atwood\n00:58:45\nYeah. I think that one of the best things in it is section\
+      \ number three, but that consists of twenty four poems, which seem to me to\
+      \ be too long. I read some of them that I like quite a lot, yes, this is true,\
+      \ but I left out some others that I also like quite a lot because it seemed\
+      \ to me that they were too long and at this particular night anyway I felt that\
+      \ I should get through as quickly as possible because we were all stifling to\
+      \ death. Um, and with that I think that I will now end the question period and\
+      \ we can all go out and have a drink of water. \n\nAudience\n00:59:24\nApplause\
+      \ [cuts out briefly].\n \nWynne Francis\n00:59:38\nI'd just like to thank Margaret\
+      \ Atwood very much for being with us tonight--\n\nAudience\n00:59:40\nLaughter.\n\
+      \ \nEND\n00:59:46\n"
+    duration: 00:59:46
+    featured: 'Yes'
+    file_path: files.spokenweb.ca>concordia>sgw>audio>all_mp3
+    file_url: https://files.spokenweb.ca/concordia/sgw/audio/all_mp3/margaret_atwood_i006-11-008.mp3
+    filename: margaret_atwood_i006-11-008.mp3
+    id: 1
+    notes: "Margaret Atwood reads from You Are Happy (Oxford University Press, 1974)\
+      \ and Power Politics (Anansi, 1971). Atwood also answers audience questions\
+      \ about her work. \n                                                       \
+      \                                                                          \
+      \     \n00:00- Unknown introducer makes an announcement about the room. [INDEX:\
+      \ Sir George Williams University, larger hall, gallery, Howard Fink.]\n00:21-\
+      \ Howard Fink answers question.\n00:22- Unknown introducer continues to make\
+      \ announcements. [INDEX: loud speakers outside, paintings, Fine Arts Department,\
+      \ artists, Howard Fink, air conditioning.]\n01:22- Audience talking\n01:30-\
+      \ Margaret Atwood talks about room set up, it is recorded by the mic [INDEX:\
+      \ room      change.]\n01:41- Audience responds, says they want to stay in the\
+      \ same room.\n01:44- Margaret Atwood tries to arrange people in the room. [INDEX:\
+      \ chairs, bench, people, rows, room.]\n04:41- Margaret Atwood continues to arrange\
+      \ audience.\n05:19- Wynne Francis introduces Margaret Atwood. [INDEX: poetry,\
+      \ fiction, poet, 1960\u2019s, The   Circle Game (Anansi, 1966), The Animals\
+      \ in that Country (Oxford University Press, 1968), Edible Woman (McClelland\
+      \ and Stewart, 1973), Surfacing (Anansi, 1971), 1972, controversial work of\
+      \ criticism, patterns in Canadian literature, nineteenth-century curiosity,\
+      \ John McTaggart quote, book published in London in 1829, victim, Canada Council,\
+      \ woman, human being, totems, manners, insanities, taught at Sir George Williams\
+      \ University between 1967-68, audience questions.]\n07:38- Margaret Atwood introduces\
+      \ \u201CNewsreel, Man and Firing Squad\u201D. [INDEX:    \tmicrophone, reading\
+      \ entirely from You are Happy (Harper & Row, 1974), photographer,      bookstore,\
+      \ order of reading, United States, what it\u2019s like to live in Canada; from\
+      \ You Are    Happy (Oxford University Press, 1974).]\n10:04- Reads \u201CNewsreel,\
+      \ Man and Firing Squad\u201D.\n11:42- Reads \u201CUseless\u201D. [INDEX: from\
+      \ You Are Happy (Oxford University Press, 1974).]\n12:35- Introduces \u201C\
+      November\u201D. [INDEX: image, sheep that died; from You Are Happy (Oxford University\
+      \ Press, 1974)]\n12:48- Reads \u201CNovember\u201D.\n13:52- Reads \u201CRepent\u201D\
+      . [INDEX: from You Are Happy (Oxford University Press, 1974).]\n14:47- Introduces\
+      \ \u201CTricks with Mirrors\u201D. [INDEX: from You Are Happy (Oxford University\
+      \ \tPress, 1974).]\n15:05- Reads \u201CTricks with Mirrors\u201D.\n17:45- Reads\
+      \ \u201CYou are Happy\u201D. [INDEX: from You Are Happy (Oxford University Press,\
+      \     1974).]\n18:48- Reads \u201CFirst Prayer\u201D. [INDEX: from You Are Happy\
+      \ (Oxford University Press, 1974).]\n20:25- Introduces \u201CIs/Not\u201D (but\
+      \ does not read it). [INDEX: hot in rom, Howard Fink. light,     Saturday movies;\
+      \ from You Are Happy (Oxford University Press, 1974).]\n22:18- Reads unknown\
+      \ poem, first line \u201CYou take my hand and I\u2019m suddenly in a bad movie...\u201D\
+      .\n23:13- Introduces \u201CThey Eat Out\u201D. [INDEX: war between Superman\
+      \ and Captain Marvel,     dinner, Plastic Man, esoteric taste; from Selected\
+      \ poems, 1965-1975 (Oxford University    Press, 1976).]\n23:28- Reads \u201C\
+      They Eat Out\u201D.\n24:44- Introduces \u201CSiren Song\u201D. [INDEX: new book,\
+      \ students of seventeenth-century literature, answer; from Selected poems, 1965-1975\
+      \ (Oxford University Press, 1976).]\n25:06- Reads \u201CSiren Song\u201D.\n\
+      26:12- Introduces \u201CCirce/Mud Poems\u201D, which is cut mid-sentence \u201C\
+      The heads of eagles no longer interest me...\u201D[INDEX: critic Allen Pearson,\
+      \ Montreal, Montreal Poet, Toronto,   Toronto Poet, \u201CSiren Song\u201D,\
+      \ woman, attract men, capes, costumes; from Selected poems, 1965-1975 (Oxford\
+      \ University Press, 1976)]\n26:57- Recording is CUT, repeats, begins mid-sentence\
+      \ reading unknown poem, which is cut mid-sentence \u201CThe heads of eagles\
+      \ no longer interest me...\u201D, last line \u201CThey would rather be trees\u201D\
+      .\n28:20- Reads \u201CIt is Not\u201D. [INDEX: perhaps \u201CIS/Not\u201D; from\
+      \ You are Happy (Oxford University Press, 1974) and Selected poems, 1965-1975\
+      \ (Oxford University Press, 1976).]\n30:37- Introduces \u201CThere is Only One\
+      \ of Everything\u201D. [INDEX: three last poems, heat; from You are Happy (Oxford\
+      \ University Press, 1974) and Selected poems, 1965-1975 (Oxford University Press,\
+      \ 1976).]\n30:54- Reads \u201CThere is Only One of Everything\u201D.\n32:20-\
+      \ Reads \u201CLate August\u201D. [INDEX: from You are Happy (Oxford University\
+      \ Press, 1974) \tand Selected poems, 1965-1975 (Oxford University Press, 1976).]\n\
+      33:26- Introduces \u201CBook of Ancestors\u201D. [INDEX: last poem of the night;\
+      \ from You are Happy (Oxford University Press, 1974) and Selected poems, 1965-1975\
+      \ (Oxford University Press, 1976).]\n33:33- Reads \u201CBook of Ancestors\u201D\
+      .\n36:47- Wynne Francis thanks Margaret Atwood and opens the floor to discussion.\n\
+      37:04- Atwood asks for questions.\n37:28- Audience #1 (female) asks first question\
+      \ about Atwood\u2019s nickname \u2018witch\u2019. [INDEX: nickname \u201Cwitch\u201D\
+      ]\n37:30- Atwood answers question. [INDEX: speech given recently at Loyola,\
+      \ reviews,   \tsupernatural powers, hypnotize readers, reviews written by men,\
+      \ witchcraft, cross,     \tvampires.]\n38:54- Audience #2 (male) asks question\
+      \ about the Edible Woman\u2019s symbology of colours. [INDEX: Edible Woman,\
+      \ grayness, William Blake reference, emergence from chaos.]\n39:17- Margaret\
+      \ Atwood answers question. [INDEX: comparison, colour, descending, poem, book,\
+      \ life, grey, pattern, Dante\u2019s Inferno, wood, state of being lost, hell,\
+      \ tortured souls.]\n40:19- Audience #2 (male) asks another question. [INDEX:\
+      \ Edible Woman, colours, complete emergence of man.]\n40:29- Margaret Atwood\
+      \ responds. [INDEX: not complete, beginning.]\n40:32- Audience #2 (male) responds.\
+      \ [INDEX: complete, universal aspect, emergence of man, colours, life.]\n40:39-\
+      \ Margaret Atwood responds. [INDEX: man, female heroine, pattern, universal\
+      \ meaning.]\n40:56- Audience #2 (male) responds. [INDEX: universal meaning,\
+      \ colour of darkness, greyness.]\n41:04- Margaret Atwood responds. [INDEX: correct.]\n\
+      41:07- Audience #2 (male) responds. [INDEX: universal meaning, colours, wrong.]\n\
+      41:14- Margaret Atwood responds. [INDEX: truth, correct pattern, critic of her\
+      \ own work,        interpretation.]\n41:34- Audience #3 (male) asks question\
+      \ about a screenplay. [INDEX: screen play, film.]\n41:39- Margaret Atwood responds\
+      \ [INDEX: finished in July, stages of making films, taking out   an auction\
+      \ [option?], payment, movie, rights, sell, script, written, package, director,\
+      \ money.]\n42:42- Audience #4 (female) asks question about film producers\u2019\
+      \ nationalities. [INDEX: American or Canadian]\n42:46- Margaret Atwood responds\
+      \ to question. [INDEX: English Canadian film industry, struggle, book, American\
+      \ symbolism, American independent producers, not MGM,       \tfaithful to the\
+      \ book, Maine, American film, ruining the symbolic pattern, Canada.]\n44:26-\
+      \ Audience #4 (female) asks another question. [INDEX: attempt to sell script\
+      \ in Canada.]\n44:30- Margaret Atwood responds to question. [INDEX: four or\
+      \ five screen plays which haven\u2019t been made, Canadian, television play,\
+      \ CBC, screenplay for Edible Woman, Marie Clarie Blais, \u201CMad Shadows\u201D\
+      , Canadian director and producer, film development corporations, commercial,\
+      \ novelists, publishing.]\n45:22- Wynne Francis asks a question about criticism.\
+      \ [INDEX: question, competition, speech on Wednesday at Loyola, comic tags,\
+      \ critical opponents, Koestler, Yogi [?], Komisars [?], literary critics, formalism,\
+      \ cultural and political awareness, ideal critic or ideal type of criticism.]\n\
+      45:51- Margaret Atwood responds. [INDEX: talents, criticism available to the\
+      \ reader, singer, dancer]\n46:08- Wynne Francis asks another question. [INDEX:\
+      \ combined talents, formal or cultural criticism]\n46:16- Audience Member #5\
+      \ (male) asks question about body and knowledge. [INDEX: body of knowledge]\n\
+      46:20- Margaret Atwood answers question. [INDEX: body of knowledge, [Northrop]\
+      \ Frye, books, Yogi-ism [sp?], reading poetry, Komasar-isim [sp?], context of\
+      \ a poem]\n47:02- Margaret Atwood calls on audience member to ask question.\n\
+      47:08- Audience #6 (male) asks question about Quebec\u2019s relation to Canada.\
+      \ [INDEX: Quebec, Canada]\n47:09- Margaret Atwood responds.\n47:11- Audience\
+      \ #6 (male) asks question about Quebecer\u2019s relation to Canada. [INDEX:\
+      \ Quebecois, Canadian]\n47:15- Margaret Atwood responds. [INDEX: Quebecois,\
+      \ Marie Claire Blais, identity, Canadian, North-American, Western European culture,\
+      \ universalist]\n47:58- Audience #7 (female) asks question about the New Canadian\
+      \ Library Series. [INDEX: opinion of the New Canadian Library Series introductions]\n\
+      48:03- Margaret Atwood answers. [INDEX: quotation from the Joy of Cooking, puff\
+      \ pastry, critical apparatus, symbolic structuring, novel, comic]\n49:09- Audience\
+      \ #8 (female) asks question about irony. [INDEX: ironist, irony]\n49:22- Margaret\
+      \ Atwood answers question.\n49:31- Audience #8 (female) asks question about\
+      \ one line of Atwood\u2019s poem. [INDEX: anger, ironic]\n49:41- Margaret Atwood\
+      \ answers question. [INDEX: double meaning, irony, definition of irony, character,\
+      \ modern literature]\n50:14- Audience #9 (female) asks question about a second\
+      \ Survival book. [INDEX: Survival 2.]\n50:16- Margaret Atwood answers question.\n\
+      50:22- Audience #9 (female) asks Atwood to elaborate.\n50:25- Margaret Atwood\
+      \ answers question. [INDEX: Survival 2, anthology, short pieces, permissions,\
+      \ expensive to produce, publish proposed table of contents, Ph.D. thesis, novel,\
+      \ second edition of Survival, paperback, General Publishing, Paper Jacks [?],\
+      \ New   Canadian Library, McMillan\u2019s, publishing industry in Canada, new\
+      \ introduction]\n52:30- Audience #10 (male) asks question about favourite poets.\
+      \ [INDEX: favourite poet]\n52:33- Margaret Atwood answers question. [INDEX:\
+      \ favourite poet, favourite poems, Margaret Avison, P.K. Page, A.M. Klein, Michael\
+      \ Ondaatje, Al Purdy, mid-Sixties, Doug [Gordon] Jones, Cornflake boxes]\n53:31-\
+      \ Margaret Atwood responds to inaudible question. [INDEX: little magazines,\
+      \ Adrienne Rich, January.]\n54:02- Audience #11 (female) asks question about\
+      \ Surfacing being autobiographical. [INDEX: Surfacing, autobiographical.]\n\
+      54:11- Margaret Atwood responds. [INDEX: vaguely, plot, fiction, setting, characters,\
+      \ invent part of characters, parents, paranoid schizophrenic, amnesia, Edible\
+      \ Woman, food, reader\u2019s reactions, comic invention.]\n55:20- Audience #12\
+      \ (female) asks question about characters. [INDEX: psychological  \tbackground,\
+      \ characters.]\n55:25- Margaret Atwood responds to question. [INDEX: believable,\
+      \ plot.]\n55:46- Audience #13 (male) asks question about Edible Woman. [INDEX:\
+      \ comical invention, Edible Woman.]\n55:49- Margaret Atwood responds to question.\n\
+      55:51- Audience #13 (male) asks question about the definition of comedy. [INDEX:\
+      \ definition of comedy.]\n55:54- Margaret Atwood responds to question. [INDEX:\
+      \ technical, Edible Woman, anti-comedy, form, young couple, series of misadventures,\
+      \ marriage, ending.]\n56:24- Audience #14 (male) asks question about latest\
+      \ writing. [INDEX: novel being written]\n56:24- Margaret Atwood responds to\
+      \ question. [INDEX: superstition, work in progress.]\n56:41- Audience #15 (female)\
+      \ asks question about Edible Woman [INDEX: Robinson Davies book.]\n56:49-57:01-\
+      \ Margaret Atwood and audience try to figure out which book was written by \
+      \       Robinson Davies. [INDEX: Fifth Busienss, Nanticore, comedy.]\n57:02-\
+      \ Audience #15 (female) asks about selections in Survival. [INDEX: couple, town,\
+      \ married, Survival.]\n57:15- Margaret Atwood responds to question. [INDEX:\
+      \ humour, magic, next two chapters of Survival 2, Samuel Marchbanks, Fifth Business,\
+      \ Nanticore, magician figure, Canadian magicians, foreigners, Gwen[dolyn] MacEwen\u2019\
+      s book No Man.]\n58:04- Audience #16 (female) asks question about No Man by\
+      \ Gwendolyn MacEwen. [INDEX: Novel.]\n58:04- Margaret Atwood responds to question.\
+      \ [INDEX: series of short stories, central story, pattern.]\n58:22- Audience\
+      \ #17 (male) asks question about selections made in Atwood\u2019s reading [INDEX:\
+      \ poems read, best, most significant from the collection, selection choices.]\n\
+      58:45- Margaret Atwood responds to question. [INDEX: section #3, consists of\
+      \ 24 poems, too long, time constraints.]\n59:380 Wynne Francis thanks Margaret\
+      \ Atwood.\n59:46.85- END OF RECORDING."
+    size: 143.5 MB
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006-11-0008_back.jpg
+    id: 2
+    title: Margaret Atwood Tape Box - Back
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006-11-0008_front.jpg
+    id: 3
+    title: Margaret Atwood Tape Box - Front
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006-11-0008_tape.jpg
+    id: 4
+    title: Margaret Atwood Tape Box - Reel
+  Item_Description:
+    genre:
+    - id: 5ddc0b13ac1f09.81447975
+      value: 'Reading: Poetry'
+    - id: 60749cc8d39528.29103547
+      value: 'Speeches: Question-and-answer period'
+    language: English
+    production_context: Documentary recording
+    source_item_ID: I006-11-008
+    swallow1_id: '1395'
+    title: ' Margaret Atwood at Sir George Williams University, The Poetry Series,
+      18 October 1974'
+    title_note: '"MARGARET ATWOOD" written on the spine of the tape''s box. "I006-11-008"
+      written on sticker on the reel. "MARGARET ATWOOD 5780 H. FINK ENGLISH 18-10-74
+      Weisman Gallery OP-Gvadnay?" written on the front of the tape''s box'
+    title_source: Cataloguer
+  Location:
+  - address: 1455, Boul de Maisonneuve Ouest, Montreal, Quebec, Canada
+    id: 1
+    latitude: '45.4972758'
+    longitude: '-73.57893043'
+    notes: Location written on the front of the tape's box indicates the venue was
+      the Weisman Gallery.
+    url: https://www.openstreetmap.org/way/22080570
+    venue: Weismann Art Gallery
+  Material_Description:
+  - AV_type: Audio
+    extent: 1/4 inch
+    generations: Master
+    id: 1
+    material_designation: Reel to Reel
+    other: 'Notes on tape box include: CENTRE FOR INSTRUCTIONAL TECHNOLOGY; Prod.
+      No: 5789; Professor/Initiator H. Fink; DEPT. English; venue noted is Weisman
+      Gallery; Op. [operator or recordist] G Uadnay [?]; check box indicates this
+      is MASTER of the recording (not a copy); '
+    other_physical_description: Cardboard tape box
+    physical_composition: Magnetic Tape
+    playback_mode: Mono
+    recording_type: Analogue
+    sound_quality: Good
+    tape_brand: Scotch
+  Notes:
+  - id: 1
+    note: 'Year-Specific Information:
+
+
+      In 1974, Atwood was living in Alliston, Ontario and had finished a year as the
+      writer-in-residence at the University of Toronto. You Are Happy came out in
+      1974, and she was working on collecting her Selected Poems which were published
+      in 1976.'
+    type: General
+  - id: 2
+    note: "Local Connections:\n\nAtwood became an important award-winning poet and\
+      \ critic in Canada by the late 60\u2018s. Sir George Williams\u2019 English\
+      \ Department hired Atwood in 1967 as an English lecturer, after she had graduated\
+      \ from Harvard. "
+    type: General
+  - id: 3
+    note: Additional research and edits by Ali Barillaro
+    type: Cataloguer
+  - id: 4
+    note: Reel-to-reel tape>CD>digital file
+    type: Preservation
+  Related_Works:
+  - URL: http://margaretatwood.ca/index.php>
+    citation: "Atwood, Margaret.  Margaret Atwood Website. June 29, 2010. \n"
+    id: 1
+  - URL: https://www.worldcat.org/title/selected-poems/oclc/977851868&referer=brief_results
+    citation: 'Atwood, Margaret. Selected Poems. Toronto: Oxford University Press,
+      1977.'
+    id: 2
+  - URL: https://www.worldcat.org/title/selected-poems-1965-1975/oclc/455883593&referer=brief_results
+    citation: 'Atwood, Margaret. Selected poems, 1965-1975. Toronto: Oxford University
+      Press, 1976. '
+    id: 3
+  - URL: https://www.worldcat.org/title/the-circle-game/oclc/1007821877&referer=brief_results
+    citation: 'Atwood, Margaret. The Circle Game. Toronto: House of Anansi, 1966. '
+    id: 4
+  - URL: https://www.worldcat.org/title/power-politics/oclc/1043970047&referer=brief_results
+    citation: 'Atwood, Margaret. Power Politics. Toronto: Anansi, 1971. '
+    id: 5
+  - URL: https://www.worldcat.org/title/you-are-happy/oclc/878900780&referer=brief_results
+    citation: 'Atwood, Margaret. You are Happy. Toronto: Oxford University Press,
+      1974.'
+    id: 6
+  - URL: https://www.worldcat.org/title/contemporary-canadian-poem-anthology/oclc/802667762&referer=brief_results
+    citation: 'Bowering, George, ed. The Contemporary Canadian Poem Anthology. Toronto:
+      Coach House Press, 1984. '
+    id: 7
+  - URL: https://www.worldcat.org/title/encyclopedia-of-post-colonial-literatures-in-english-volume-1/oclc/636622714&referer=brief_results
+    citation: "Findley, Timothy. \u201CAtwood, Margaret (1939-)\u201D. Routledge Encyclopedia\
+      \ of Post-Colonial         Literatures in English. Benson, Eugene; L.W. Connolly\
+      \ (eds). London: Routledge, 1994. 2 vols."
+    id: 8
+  - URL: https://www.worldcat.org/title/15-canadian-poets-times-2/oclc/622296707&referer=brief_results
+    citation: 'Geddes, Gary (ed). Fifteen Canadian Poets Times Two. Toronto: Oxford
+      University Press, 1988.'
+    id: 9
+  - URL: https://www.worldcat.org/title/poets-of-contemporary-canada-1960-1970-edited-and-with-an-introduction-by-eli-mandel/oclc/1202953921&referer=brief_results
+    citation: 'Mandel, Eli (ed). Poets of Contemporary Canada 1960-1970. Montreal:
+      McClelland and Stewart, 1972. '
+    id: 10
+  - URL: https://www.worldcat.org/title/encyclopedia-of-the-novel/oclc/807436716&referer=brief_results
+    citation: "Rowland, Susan. \u201CMargaret Atwood 1939- (Canadian)\u201D. Encyclopedia\
+      \ of the Novel. Schellinger, Paul (ed.); Christopher Hudson, Marijke Rijsberman\
+      \ (asst. eds.). Chicago: Fitzroy Dearborn Publishers, 1998. 2 vols. "
+    id: 11
+  - URL: http://news.google.com/newspapers?id=waYtAAAAIBAJ&sjid=u58FAAAAIBAJ&pg=7250,4345207&dq=sir+george+williams+poetry&hl=en
+    citation: "Stephens, Anna. \u201CPoetry- Anywhere, Anytime\u201D. Montreal: The\
+      \ Gazette. 20 October 1967, page 10. "
+    id: 12
+  - citation: "Kibble, Matthew. \u201CAtwood, Margaret Eleanor, 1939-\u201D. Literature\
+      \ Online biography. Proquest Information and Learning Company, H.W. Wilson Company,\
+      \ 2006. "
+    id: 13
+  Rights:
+    access: Closed
+  cataloguer:
+    email: mahtab.banihashemi@gmail.com
+    lastname: Banihashemi
+    name: Mahtab
+  classification:
+  - URI: ''
+    class_name: series
+    contact email: ''
+    description: ''
+    id: '38'
+    label: The Poetry Series
+    parent_id: '24'
+    wikidata url: ''
+  - Contributing Unit: Records Management and Archives
+    Old Swallow1 ID: ''
+    Persistent URL: http://archives.concordia.ca/I086
+    Source Collection: SGWU Reading Series-Concordia University Department of English
+      fonds
+    Source Collection Description: The fonds consists of some administrative records
+      of the SGWU Department of English and the Concordia Department of English between
+      1971 and 2000. It also consists of some SGWU Department of English records related
+      to student academic activities in the 1940s and to public readings and lectures,
+      and a few interviews, produced between 1966 and 1972. The fonds mainly includes
+      minutes of departmental meetings and some course timetables. It also includes
+      some student papers in bound volumes and 63 sound recordings (80 audio reels)
+      mainly composed of poetry readings (see the Concordia SpokenWeb project which
+      uses this material) but also a few lectures given at SGWU. There are also loose
+      typed sheets describing some of the SGWU poetry readings.
+    Source Collection ID: I086
+    URI: ''
+    class_name: collection
+    id: '24'
+    label: SGWU Reading Series-Concordia University Department of English fonds
+    parent_id: '4'
+  - URI: ''
+    class_name: partner institution
+    description: ''
+    id: '4'
+    label: Concordia University
+    parent_id: '0'
+  create_date: '2023-01-31 20:57:01'
+  last_modified: '2023-10-19 15:15:50'
+  schema: Swallow JSON
+  schema_definition: spoken_web
+  swallow_id: '1253'
+- Content:
+    contents: "anthony_hecht_i006-11-041.mp3\n\nIntroducer\n00:00:00\nOn behalf of\
+      \ the Poetry Reading Committee of this university, Mr. Roy Kiyooka [https://www.wikidata.org/wiki/Q3445789],\
+      \ Mrs. Wynne Francis, Mr. Howard Fink, Mr. Irving Layton [https://www.wikidata.org/wiki/Q1673289],\
+      \ and Mr. Stanton Hoffman, I wish to welcome you to the second reading in our\
+      \ fall series. The reader for this evening is Mr. Anthony Hecht [https://www.wikidata.org/wiki/Q3618497]\
+      \ of New York City [https://www.wikidata.org/wiki/Q60]. Mr. Hecht was born in\
+      \ New York City. He is a fellow of the American Academy in Rome [https://www.wikidata.org/wiki/Q463271].\
+      \ He is the author of two volumes of poetry, A Summoning of Stones, which was\
+      \ published by Macmillan [https://www.wikidata.org/wiki/Q2108217] in New York\
+      \ City in 1954, and a later volume published in Northampton, Massachusetts [https://www.wikidata.org/wiki/Q49186]\
+      \ in 1958, Seven Deadly Sins. Mr. Hecht is a poetry editor of The Hudson Review\
+      \ [https://www.wikidata.org/wiki/Q15708605]. Mr. Hecht has also been a faculty\
+      \ member of such universities as Smith [https://www.wikidata.org/wiki/Q49204],\
+      \ New York University [https://www.wikidata.org/wiki/Q49210] and Bard College\
+      \ [https://www.wikidata.org/wiki/Q49109], and he will be joining the faculty\
+      \ of the University of Rochester [https://www.wikidata.org/wiki/Q149990] very\
+      \ soon. Mr. Hecht is the author of three forthcoming volumes: The Hard Hours,\
+      \ which is to be published soon by Viking [https://www.wikidata.org/wiki/Q921536],\
+      \ a volume called Double Dactyls, which is to appear about Christmas and is\
+      \ to be published by Atheneum [https://www.wikidata.org/wiki/Q4813415], and\
+      \ a volume of verse epigrams to the engravings of Thomas Bewick [https://www.wikidata.org/wiki/Q437594],\
+      \ which is to be published by the Harvard University Press [https://www.wikidata.org/wiki/Q1587900].\
+      \ Ladies and gentlemen, Mr. Anthony Hecht. \n \nAnthony Hecht\n00:01:36\nThank\
+      \ you very much. It's a pleasure to be here, this is my first trip to Canada\
+      \ [https://www.wikidata.org/wiki/Q16], and I regret that it should be so brief.\
+      \ I must leave tomorrow, but I'm struck by the frigidity of the weather and\
+      \ the warmth of the greeting that I received upon arriving. I'd like to begin\
+      \ with a poem which I'll, is set in Italy [https://www.wikidata.org/wiki/Q38],\
+      \ where I spent quite a while. It's called \"A Hill\", and it's what...about\
+      \ a purported visionary experience. \n \nAnthony Hecht\n00:02:21\nReads \"A\
+      \ Hill\" from The Hard Hours..\n \nAnthony Hecht\n00:04:50\nThe next is called\
+      \ \"A Letter\". Some of these, I think, will require some sort of explanatory\
+      \ comment from me, but I don't think this will. \n \nAnthony Hecht\n00:04:59\n\
+      Reads \"A Letter\" from The Hard Hours.\n \nAnthony Hecht\n00:06:44\nThe next\
+      \ is called \"The Vow\". I should say that all the poems that I want to read\
+      \ to you this evening are from a book called The Hard Hours. They...the book\
+      \ is, I fear, for better or for worse, somewhat on the grim side, as the title\
+      \ is meant to indicate. It perhaps is a corrective to the abundant cheerfulness\
+      \ of my first book. But I hope that there were a few light moments here and\
+      \ there. This one, on the other--is somewhat grim. It is in fact about a miscarriage.\
+      \ And I had better explain to you that a large part of the second stanza, and\
+      \ all of the third stanza is spoken by the ghost of the child who fails to be\
+      \ born. It is called \"The Vow\".\n \nAnthony Hecht\n00:07:42\nReads \"The Vow\"\
+      \ from The Hard Hours.\n \nAnthony Hecht\n00:10:01\nThe next one is also somewhat\
+      \ on the grim side, but it requires an appeasing little note of explanation.\
+      \ Its title is \"More Light! More Light!\" which purport to be the last words\
+      \ of Goethe [https://www.wikidata.org/wiki/Q5879] on his deathbed. There's been\
+      \ a good deal of discussion and dispute as to quite what he meant at the time,\
+      \ which may simply have been to raise the shade. But inasmuch as he is regarded\
+      \ as the spirit of the German Enlightenment, a great deal more profound significance\
+      \ is normally attached to those words. He plays a very minor, somewhat ghostly\
+      \ role in this poem, which is a deliberate and violent contrast, so violent,\
+      \ indeed, that the poem was rejected by The New Yorker [https://www.wikidata.org/wiki/Q217305]\
+      \ on the grounds that the contrast was much too violent for their taste. Between\
+      \ an execution, which is in fact a conflation I've made myself of several executions\
+      \ that took place in England [https://www.wikidata.org/wiki/Q21] during the\
+      \ Renaissance [https://www.wikidata.org/wiki/Q4692], and an execution that took\
+      \ place in the Buchenwald concentration camp [https://www.wikidata.org/wiki/Q152802]\
+      \ during the Second World War [https://www.wikidata.org/wiki/Q362], and the\
+      \ details of which I got from a book by Eugene Kogan, who was himself a prisoner\
+      \ there for five years and survived, miraculously, and was then flown to England\
+      \ to help draw up the indictments that were used, [coughs], excuse me, at the\
+      \ Nuremberg Trials [https://www.wikidata.org/wiki/Q80130]. Goethe's role, his\
+      \ ghostly role in this, is explained by the fact that most prisoners who were\
+      \ brought to Buchenwald were brought by train, and there was no railroad station\
+      \ there at the camp, so the prisoners were, disembarked at the nearest railroad\
+      \ station, which was Weimar [https://www.wikidata.org/wiki/Q3955], and they\
+      \ walked the rest of the way from there. \n \nAnthony Hecht\n00:12:01\nReads\
+      \ \"More Light! More Light!\" from The Hard Hours.\n \nAnthony Hecht\n00:14:36\n\
+      The next is a little lighter, gratefully. But it has its gruesome aspects too,\
+      \ as a matter of fact. It is called \"The Man Who Married Magdalen: Variation\
+      \ on a Theme by Louis Simpson\". Louis Simpson [https://www.wikidata.org/wiki/Q1871997],\
+      \ a fine poet and very old friend of mine. A road poem in one of his early books,\
+      \ called \"The Man Who Married Magdalen\", a fine and delicate poem, in which\
+      \ he imagines that this man who raged and stormed throughout his married life,\
+      \ upon the death of his wife finds it in his heart to forgive her and to acknowledge\
+      \ his abiding love for her. In fact, if I can remember the last stanza, it goes,\
+      \ \"But when he woke, and woke alone, he wept and would deny the loose behaviour\
+      \ of the bone, and the immodest thigh\". I have chosen to make him far less\
+      \ forgiving in my version. He is a very angry man, and the whole poem takes\
+      \ place in a bar where he has been releasing his anger in a bibulous way for\
+      \ some time. His anger is not only personal, however, it's also theological.\
+      \ He is someone who believes in and accepts the ancient dispensation according\
+      \ to which Mary Magdalene [https://www.wikidata.org/wiki/Q63070] had done something\
+      \ which could not, in fact, be so easily forgiven. And he regards the new dispensation\
+      \ as an antinomian heresy which leaves him bewildered and accounts for the rather\
+      \ promiscuous behaviour he finds all around him in the bar. I ought to tell\
+      \ you also that I went on a reading tour of New England [https://www.wikidata.org/wiki/Q18389]\
+      \ a few years ago, and I planned to include this, but when I got to...it has\
+      \ some frankly dirty language in the second stanza, and I decided that it was\
+      \ unbecoming at certain colleges, [audience laughter], but I was assured by\
+      \ a friend of mine on the faculty at Wellesley [https://www.wikidata.org/wiki/Q49205]\
+      \ that the girls there were tough, and they could take it.  [Audience laughter].\
+      \ He liked it, and he thought I should read it. And indeed, I did. And nobody\
+      \ batted an eye. So, from then on, without compunction at all, I read it everywhere\
+      \ else, and when I got to Mount Hollyhock, [audience laughter], there I had\
+      \ every intention of reading it, but they were not only taping it, as you are\
+      \ here this evening, but they were taping it for radio broadcast, so I felt\
+      \ obliged to warn the Federal Communications Commission [https://www.wikidata.org/wiki/Q128831]\
+      \ [audience laughter] that this was the sort of thing that they would probably\
+      \ have to excise. And after the tour was over, I got a postcard from a friend\
+      \ of mine in that bastion of propriety, Boston [https://www.wikidata.org/wiki/Q100],\
+      \ saying that he had heard the whole broadcast with nothing cut out, so I take\
+      \ it there's absolutely nothing wrong with it now [audience laughter]. It has,\
+      \ in any case, a lofty epigraph from the Book of Jonah [https://www.wikidata.org/wiki/Q178819]\
+      \ [audience laughter], which says, \"Then said the Lord, 'Dost thou well, to\
+      \ be angry?'\u201D\n \nAnthony Hecht\n00:17:57\nReads \"The Man Who Married\
+      \ Magdalen: Variation on a Theme by Louis Simpson\" from The Hard Hours [audience\
+      \ laughter throughout].\n \nAnthony Hecht\n00:20:26\nA poem of a somewhat different\
+      \ sort, called \"Message from the City\".\n \nAnthony Hecht\n00:20:37\nReads\
+      \ \"Message from the City\" from The Hard Hours.\n \nAnthony Hecht\n00:23:02\n\
+      The poem I want to read next is also, again, on the somewhat grim side. It is,\
+      \ in fact, incomplete, but it stands altogether, by itself. It's going to be\
+      \ longer, but it is a unit, as it appears, or as I shall read it to you, and\
+      \ it's called, in its present state, \"The Rune\".\n \nAnthony Hecht\n00:23:35\n\
+      Reads \"The Rune\" from The Hard Hours.\n \nAnthony Hecht\n00:27:54\nI guess\
+      \ a really violent change of pace is required, and I can provide it. But you\
+      \ are not to be spared as easily as that. There's another sort of wracking one\
+      \ that comes up in a minute. However, I can interject something in between.\
+      \ There's a little sort of period piece, a Restoration comedy song, sort of,\
+      \ called \"The Song of the Flea\". It was written...there were a group of poems\
+      \ that I wrote in collaboration with an artist. We did a bestiary together,\
+      \ and he did a whole bunch of very handsome lithographs of animals, and I wrote\
+      \ a few animal poems, and this is one of them.\n \nAnthony Hecht\n00:28:45\n\
+      Reads \"The Song of the Flea\" from The Hard Hours.\n \nAnthony Hecht\n00:29:40\n\
+      Now this, this next, is quite frankly a stinker, I've got to warn you. It's\
+      \ a very unnerving poem. It's a colloquy; there are two voices, but I'm sure\
+      \ you'll have no difficulty telling them apart. There is one speaker who is\
+      \ a kind of compulsive talker, and he has a very patient and somewhat helpless\
+      \ auditor. The poem is called \"Behold the Lilies of the Field\".\n \nAnthony\
+      \ Hecht\n00:30:18\nReads \"Behold the Lilies of the Field\" from The Hard Hours.\n\
+      \ \nAnthony Hecht\n00:34:34\nThe next is a blessed relief. It's called \"Jason\"\
+      , which is the name of my older son, and it's a poem written to celebrate his\
+      \ birth. He was born at the time I was teaching at Smith, and he was born on\
+      \ a Sunday, which has some bearing on the poem, but it conveniently avoided\
+      \ my, disrupting my academic obligations. And it has an epigraph from Doctor\
+      \ Faustus [https://www.wikidata.org/wiki/Q50919], which goes, \"And from America,\
+      \ the Golden Fleece\".\n \nAnthony Hecht\n00:35:16\nReads \"Jason\" from The\
+      \ Hard Hours.\n \nAnthony Hecht\n00:37:12\nThe next one is also, this is also\
+      \ rather cheery too--well, not really. I told you that I had gone on this New\
+      \ England tour a few years ago, and I began it in Maine [https://www.wikidata.org/wiki/Q724].\
+      \ Well, I may have been misled [distortion], but I was told at the two or three\
+      \ colleges and universities where I read that Maine was a dry state, and I had\
+      \ so arranged my poems, completely unconsciously, that I had a whole bunch of\
+      \ them that all took place in bars, in bars altogether [audience laughter].\
+      \ So I had the feeling as I was reading--I couldn't stop, you see, there I was--\
+      \ after the third poem, I felt that I appeared to be an obsessive alcoholic.\
+      \ [Audience laughter]. This also takes place in a bar. I was born and brought\
+      \ up in New York City, and remember it from the time when Third Avenue had an\
+      \ elevator train that ran down its length. Now, that has all been torn down.\
+      \ But in the old days, not only did it have the elevator train, but it was lined\
+      \ on both sides all the way up and down with bars. The bars are still there.\
+      \ But the advantage of the El was that it cast a nice, gloomy shadow over the\
+      \ whole avenue even on the brightest days, so that you weren't obliged to face\
+      \ utter reality as soon as you stepped outside [audience laughter]. There was\
+      \ a sort of modulating gloom that you got out into. Now that's been torn down,\
+      \ and it's tougher than it was. The poem is called \"Third Avenue in Sunlight\"\
+      .\n \nAnthony Hecht\n00:38:45\nReads \"Third Avenue in Sunlight\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:40:31\nThere are two more poems I should like\
+      \ to read. The first of these is called \"Birdwatchers of America\". It has\
+      \ an epigraph from the journals of Baudelaire [https://www.wikidata.org/wiki/Q501],\
+      \ very near the end of his life. Baudelaire wrote as follows: \"I suffer now\
+      \ continually from vertigo, and today, the 23rd of January, 1862, I received\
+      \ a singular warning. I felt the wind of the wing of madness pass over me\"\
+      .\n \nAnthony Hecht\n00:41:14\nReads \"Birdwatchers of America\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:42:50\nThis is called \"The End of the Weekend\"\
+      .\n \nAnthony Hecht\n00:42:56\nReads \"The End of the Weekend\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:44:38\nFinally, there is a poem that I must remind\
+      \ you of which I enormously admire, by Matthew Arnold [https://www.wikidata.org/wiki/Q271032].\
+      \ \"Dover Beach\" [https://www.wikidata.org/wiki/Q5302469]. I have, in spite\
+      \ of my admiration for it, ventured to write a somewhat impertinent commentary\
+      \ upon it, which is called \"The Dover Bitch\" and subtitled [audience laughter],\
+      \ \"A Criticism of Life\", which is what Arnold said poetry ought to be. \n\
+      \ \nAnthony Hecht\n00:45:13\nReads \"The Dover Bitch: A Criticism of Life\"\
+      \ from The Hard Hours [audience laughter throughout].\n \nEND\n00:46:55\n[Cut\
+      \ off abruptly]."
+    notes: Anthony Hecht reads from his book The Hard Hours which was published later
+      in 1967 by Atheneum Press.
+  Contributors:
+  - id: 1
+    name: Unknown
+    role:
+    - id: 6063639529fe75.73289710
+      value: Speaker
+    - id: 6063639ab8dee1.13714004
+      value: Series organizer
+  Creators:
+  - dates: 1923-2004
+    id: 1
+    name: Hecht, Anthony
+    notes: "American poet Anthony Hecht was born in New York City on January 16th,\
+      \ 1923. Hecht has admitted that it was only in his freshman year at Bard College\
+      \ that he became interested in poetry. Upon graduating from Bard in 1944, he\
+      \ was drafted into the United States Army and served in Western Europe and Japan.\
+      \ Hecht was especially impacted by the release of Jews in the concentration\
+      \ camps, a subject that is echoed throughout his poetry. On his return, Hecht\
+      \ was convinced to study with John Crowe Ransom at Kenyon College, and Ransom\
+      \ became a major influence in Hecht\u2019s poetic and intellectual formation.\
+      \ Hecht\u2019s poetry was first published in magazines like the Hudson Review,\
+      \ the Kenyon Review and the New Yorker, and in 1950 he won the Prix de Rome\
+      \ bestowed by the American Academy of Arts and Letters. Hecht\u2019s first book,\
+      \ A Summoning of Stones (MacMillan, 1954) was published, along with a limited\
+      \ edition pamphlet named The Seven Deadly Sins (Gehenna Press, 1954). Hecht\
+      \ then taught at Smith College in Northampton from 1956 to 1959, and then at\
+      \ Bard College from 1961 until 1967. It was at this point that Hecht began to\
+      \ travel on reading tours of his poetry. His next publication, Jiggery Pokery:\
+      \ A Compendium of Double Dactyls (Atheneum, 1966), with John Hollander and Milton\
+      \ Glaser, compiled a new light verse form called \u2018double-dactyl\u2019,\
+      \ which they had invented. A year later, Hecht released his second collection\
+      \ of verse, The Hard Hours (Atheneum, 1967), and took a position at the University\
+      \ of Rochester. In the next few years, Hecht translated Aeschylus\u2019 tragedy\
+      \ of war, Seven Against Thebes (Oxford University Press, 1973) with Helen Bacon.\
+      \ He was also the visiting professor at Washington University (1971), Harvard\
+      \ (1973), and at Yale (1977). Hecht then published collections of poetry, Millions\
+      \ of Strange Shadows (Atheneum, 1977) and The Venetian Vespers (Atheneum, 1979),\
+      \ a collection of criticism, Obbligati (Atheneum, 1986), The Transparent Man\
+      \ (Knopf, 1990) and Flight Among the Tombs (Knopf, 1990). Hecht retired in the\
+      \ early 1990s from his post at Rochester, but remained active and published\
+      \ Hidden Law (1993), a book-length study of Auden\u2019s poetry, and provided\
+      \ the introduction to \u201CThe New Cambridge Shakespeare Sonnets\u201D in 1996.\
+      \ Hecht was the first American poet to be invited to lecture at the Mellon Lectures\
+      \ at the National Gallery of Art in 1992. Hecht published his last collection\
+      \ of poetry, The Darkness and the Light (Knopf) in 2001. Anthony Hecht died\
+      \ of Non-Hodgkin's Lymphoma on October 20, 2004."
+    role:
+    - id: 6063608ef37fc5.52917575
+      value: Author
+    - id: 6063609e2eae73.41122925
+      value: Performer
+    url: http://viaf.org/viaf/76363549
+  Dates:
+  - date: 1966 10 21
+    id: 1
+    notes: Date is approximate, using other recordings and readings to guess the time
+      period (October-November 1966)
+    source: Previous researcher
+    type: Performance Date
+  Digital_File_Description:
+  - content_type: Sound Recording
+    contents: "Introducer\n00:00:00\nOn behalf of the Poetry Reading Committee of\
+      \ this university, Mr. Roy Kiyooka [https://www.wikidata.org/wiki/Q3445789],\
+      \ Mrs. Wynne Francis, Mr. Howard Fink, Mr. Irving Layton [https://www.wikidata.org/wiki/Q1673289],\
+      \ and Mr. Stanton Hoffman, I wish to welcome you to the second reading in our\
+      \ fall series. The reader for this evening is Mr. Anthony Hecht [https://www.wikidata.org/wiki/Q3618497]\
+      \ of New York City [https://www.wikidata.org/wiki/Q60]. Mr. Hecht was born in\
+      \ New York City. He is a fellow of the American Academy in Rome [https://www.wikidata.org/wiki/Q463271].\
+      \ He is the author of two volumes of poetry, A Summoning of Stones, which was\
+      \ published by Macmillan [https://www.wikidata.org/wiki/Q2108217] in New York\
+      \ City in 1954, and a later volume published in Northampton, Massachusetts [https://www.wikidata.org/wiki/Q49186]\
+      \ in 1958, Seven Deadly Sins. Mr. Hecht is a poetry editor of The Hudson Review\
+      \ [https://www.wikidata.org/wiki/Q15708605]. Mr. Hecht has also been a faculty\
+      \ member of such universities as Smith [https://www.wikidata.org/wiki/Q49204],\
+      \ New York University [https://www.wikidata.org/wiki/Q49210] and Bard College\
+      \ [https://www.wikidata.org/wiki/Q49109], and he will be joining the faculty\
+      \ of the University of Rochester [https://www.wikidata.org/wiki/Q149990] very\
+      \ soon. Mr. Hecht is the author of three forthcoming volumes: The Hard Hours,\
+      \ which is to be published soon by Viking [https://www.wikidata.org/wiki/Q921536],\
+      \ a volume called Double Dactyls, which is to appear about Christmas and is\
+      \ to be published by Atheneum [https://www.wikidata.org/wiki/Q4813415], and\
+      \ a volume of verse epigrams to the engravings of Thomas Bewick [https://www.wikidata.org/wiki/Q437594],\
+      \ which is to be published by the Harvard University Press [https://www.wikidata.org/wiki/Q1587900].\
+      \ Ladies and gentlemen, Mr. Anthony Hecht. \n \nAnthony Hecht\n00:01:36\nThank\
+      \ you very much. It's a pleasure to be here, this is my first trip to Canada\
+      \ [https://www.wikidata.org/wiki/Q16], and I regret that it should be so brief.\
+      \ I must leave tomorrow, but I'm struck by the frigidity of the weather and\
+      \ the warmth of the greeting that I received upon arriving. I'd like to begin\
+      \ with a poem which I'll, is set in Italy [https://www.wikidata.org/wiki/Q38],\
+      \ where I spent quite a while. It's called \"A Hill\", and it's what...about\
+      \ a purported visionary experience. \n \nAnthony Hecht\n00:02:21\nReads \"A\
+      \ Hill\" from The Hard Hours..\n \nAnthony Hecht\n00:04:50\nThe next is called\
+      \ \"A Letter\". Some of these, I think, will require some sort of explanatory\
+      \ comment from me, but I don't think this will. \n \nAnthony Hecht\n00:04:59\n\
+      Reads \"A Letter\" from The Hard Hours.\n \nAnthony Hecht\n00:06:44\nThe next\
+      \ is called \"The Vow\". I should say that all the poems that I want to read\
+      \ to you this evening are from a book called The Hard Hours. They...the book\
+      \ is, I fear, for better or for worse, somewhat on the grim side, as the title\
+      \ is meant to indicate. It perhaps is a corrective to the abundant cheerfulness\
+      \ of my first book. But I hope that there were a few light moments here and\
+      \ there. This one, on the other--is somewhat grim. It is in fact about a miscarriage.\
+      \ And I had better explain to you that a large part of the second stanza, and\
+      \ all of the third stanza is spoken by the ghost of the child who fails to be\
+      \ born. It is called \"The Vow\".\n \nAnthony Hecht\n00:07:42\nReads \"The Vow\"\
+      \ from The Hard Hours.\n \nAnthony Hecht\n00:10:01\nThe next one is also somewhat\
+      \ on the grim side, but it requires an appeasing little note of explanation.\
+      \ Its title is \"More Light! More Light!\" which purport to be the last words\
+      \ of Goethe [https://www.wikidata.org/wiki/Q5879] on his deathbed. There's been\
+      \ a good deal of discussion and dispute as to quite what he meant at the time,\
+      \ which may simply have been to raise the shade. But inasmuch as he is regarded\
+      \ as the spirit of the German Enlightenment, a great deal more profound significance\
+      \ is normally attached to those words. He plays a very minor, somewhat ghostly\
+      \ role in this poem, which is a deliberate and violent contrast, so violent,\
+      \ indeed, that the poem was rejected by The New Yorker [https://www.wikidata.org/wiki/Q217305]\
+      \ on the grounds that the contrast was much too violent for their taste. Between\
+      \ an execution, which is in fact a conflation I've made myself of several executions\
+      \ that took place in England [https://www.wikidata.org/wiki/Q21] during the\
+      \ Renaissance [https://www.wikidata.org/wiki/Q4692], and an execution that took\
+      \ place in the Buchenwald concentration camp [https://www.wikidata.org/wiki/Q152802]\
+      \ during the Second World War [https://www.wikidata.org/wiki/Q362], and the\
+      \ details of which I got from a book by Eugene Kogan, who was himself a prisoner\
+      \ there for five years and survived, miraculously, and was then flown to England\
+      \ to help draw up the indictments that were used, [coughs], excuse me, at the\
+      \ Nuremberg Trials [https://www.wikidata.org/wiki/Q80130]. Goethe's role, his\
+      \ ghostly role in this, is explained by the fact that most prisoners who were\
+      \ brought to Buchenwald were brought by train, and there was no railroad station\
+      \ there at the camp, so the prisoners were, disembarked at the nearest railroad\
+      \ station, which was Weimar [https://www.wikidata.org/wiki/Q3955], and they\
+      \ walked the rest of the way from there. \n \nAnthony Hecht\n00:12:01\nReads\
+      \ \"More Light! More Light!\" from The Hard Hours.\n \nAnthony Hecht\n00:14:36\n\
+      The next is a little lighter, gratefully. But it has its gruesome aspects too,\
+      \ as a matter of fact. It is called \"The Man Who Married Magdalen: Variation\
+      \ on a Theme by Louis Simpson\". Louis Simpson [https://www.wikidata.org/wiki/Q1871997],\
+      \ a fine poet and very old friend of mine. A road poem in one of his early books,\
+      \ called \"The Man Who Married Magdalen\", a fine and delicate poem, in which\
+      \ he imagines that this man who raged and stormed throughout his married life,\
+      \ upon the death of his wife finds it in his heart to forgive her and to acknowledge\
+      \ his abiding love for her. In fact, if I can remember the last stanza, it goes,\
+      \ \"But when he woke, and woke alone, he wept and would deny the loose behaviour\
+      \ of the bone, and the immodest thigh\". I have chosen to make him far less\
+      \ forgiving in my version. He is a very angry man, and the whole poem takes\
+      \ place in a bar where he has been releasing his anger in a bibulous way for\
+      \ some time. His anger is not only personal, however, it's also theological.\
+      \ He is someone who believes in and accepts the ancient dispensation according\
+      \ to which Mary Magdalene [https://www.wikidata.org/wiki/Q63070] had done something\
+      \ which could not, in fact, be so easily forgiven. And he regards the new dispensation\
+      \ as an antinomian heresy which leaves him bewildered and accounts for the rather\
+      \ promiscuous behaviour he finds all around him in the bar. I ought to tell\
+      \ you also that I went on a reading tour of New England [https://www.wikidata.org/wiki/Q18389]\
+      \ a few years ago, and I planned to include this, but when I got to...it has\
+      \ some frankly dirty language in the second stanza, and I decided that it was\
+      \ unbecoming at certain colleges, [audience laughter], but I was assured by\
+      \ a friend of mine on the faculty at Wellesley [https://www.wikidata.org/wiki/Q49205]\
+      \ that the girls there were tough, and they could take it.  [Audience laughter].\
+      \ He liked it, and he thought I should read it. And indeed, I did. And nobody\
+      \ batted an eye. So, from then on, without compunction at all, I read it everywhere\
+      \ else, and when I got to Mount Hollyhock, [audience laughter], there I had\
+      \ every intention of reading it, but they were not only taping it, as you are\
+      \ here this evening, but they were taping it for radio broadcast, so I felt\
+      \ obliged to warn the Federal Communications Commission [https://www.wikidata.org/wiki/Q128831]\
+      \ [audience laughter] that this was the sort of thing that they would probably\
+      \ have to excise. And after the tour was over, I got a postcard from a friend\
+      \ of mine in that bastion of propriety, Boston [https://www.wikidata.org/wiki/Q100],\
+      \ saying that he had heard the whole broadcast with nothing cut out, so I take\
+      \ it there's absolutely nothing wrong with it now [audience laughter]. It has,\
+      \ in any case, a lofty epigraph from the Book of Jonah [https://www.wikidata.org/wiki/Q178819]\
+      \ [audience laughter], which says, \"Then said the Lord, 'Dost thou well, to\
+      \ be angry?'\u201D\n \nAnthony Hecht\n00:17:57\nReads \"The Man Who Married\
+      \ Magdalen: Variation on a Theme by Louis Simpson\" from The Hard Hours [audience\
+      \ laughter throughout].\n \nAnthony Hecht\n00:20:26\nA poem of a somewhat different\
+      \ sort, called \"Message from the City\".\n \nAnthony Hecht\n00:20:37\nReads\
+      \ \"Message from the City\" from The Hard Hours.\n \nAnthony Hecht\n00:23:02\n\
+      The poem I want to read next is also, again, on the somewhat grim side. It is,\
+      \ in fact, incomplete, but it stands altogether, by itself. It's going to be\
+      \ longer, but it is a unit, as it appears, or as I shall read it to you, and\
+      \ it's called, in its present state, \"The Rune\".\n \nAnthony Hecht\n00:23:35\n\
+      Reads \"The Rune\" from The Hard Hours.\n \nAnthony Hecht\n00:27:54\nI guess\
+      \ a really violent change of pace is required, and I can provide it. But you\
+      \ are not to be spared as easily as that. There's another sort of wracking one\
+      \ that comes up in a minute. However, I can interject something in between.\
+      \ There's a little sort of period piece, a Restoration comedy song, sort of,\
+      \ called \"The Song of the Flea\". It was written...there were a group of poems\
+      \ that I wrote in collaboration with an artist. We did a bestiary together,\
+      \ and he did a whole bunch of very handsome lithographs of animals, and I wrote\
+      \ a few animal poems, and this is one of them.\n \nAnthony Hecht\n00:28:45\n\
+      Reads \"The Song of the Flea\" from The Hard Hours.\n \nAnthony Hecht\n00:29:40\n\
+      Now this, this next, is quite frankly a stinker, I've got to warn you. It's\
+      \ a very unnerving poem. It's a colloquy; there are two voices, but I'm sure\
+      \ you'll have no difficulty telling them apart. There is one speaker who is\
+      \ a kind of compulsive talker, and he has a very patient and somewhat helpless\
+      \ auditor. The poem is called \"Behold the Lilies of the Field\".\n \nAnthony\
+      \ Hecht\n00:30:18\nReads \"Behold the Lilies of the Field\" from The Hard Hours.\n\
+      \ \nAnthony Hecht\n00:34:34\nThe next is a blessed relief. It's called \"Jason\"\
+      , which is the name of my older son, and it's a poem written to celebrate his\
+      \ birth. He was born at the time I was teaching at Smith, and he was born on\
+      \ a Sunday, which has some bearing on the poem, but it conveniently avoided\
+      \ my, disrupting my academic obligations. And it has an epigraph from Doctor\
+      \ Faustus [https://www.wikidata.org/wiki/Q50919], which goes, \"And from America,\
+      \ the Golden Fleece\".\n \nAnthony Hecht\n00:35:16\nReads \"Jason\" from The\
+      \ Hard Hours.\n \nAnthony Hecht\n00:37:12\nThe next one is also, this is also\
+      \ rather cheery too--well, not really. I told you that I had gone on this New\
+      \ England tour a few years ago, and I began it in Maine [https://www.wikidata.org/wiki/Q724].\
+      \ Well, I may have been misled [distortion], but I was told at the two or three\
+      \ colleges and universities where I read that Maine was a dry state, and I had\
+      \ so arranged my poems, completely unconsciously, that I had a whole bunch of\
+      \ them that all took place in bars, in bars altogether [audience laughter].\
+      \ So I had the feeling as I was reading--I couldn't stop, you see, there I was--\
+      \ after the third poem, I felt that I appeared to be an obsessive alcoholic.\
+      \ [Audience laughter]. This also takes place in a bar. I was born and brought\
+      \ up in New York City, and remember it from the time when Third Avenue had an\
+      \ elevator train that ran down its length. Now, that has all been torn down.\
+      \ But in the old days, not only did it have the elevator train, but it was lined\
+      \ on both sides all the way up and down with bars. The bars are still there.\
+      \ But the advantage of the El was that it cast a nice, gloomy shadow over the\
+      \ whole avenue even on the brightest days, so that you weren't obliged to face\
+      \ utter reality as soon as you stepped outside [audience laughter]. There was\
+      \ a sort of modulating gloom that you got out into. Now that's been torn down,\
+      \ and it's tougher than it was. The poem is called \"Third Avenue in Sunlight\"\
+      .\n \nAnthony Hecht\n00:38:45\nReads \"Third Avenue in Sunlight\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:40:31\nThere are two more poems I should like\
+      \ to read. The first of these is called \"Birdwatchers of America\". It has\
+      \ an epigraph from the journals of Baudelaire [https://www.wikidata.org/wiki/Q501],\
+      \ very near the end of his life. Baudelaire wrote as follows: \"I suffer now\
+      \ continually from vertigo, and today, the 23rd of January, 1862, I received\
+      \ a singular warning. I felt the wind of the wing of madness pass over me\"\
+      .\n \nAnthony Hecht\n00:41:14\nReads \"Birdwatchers of America\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:42:50\nThis is called \"The End of the Weekend\"\
+      .\n \nAnthony Hecht\n00:42:56\nReads \"The End of the Weekend\" from The Hard\
+      \ Hours.\n \nAnthony Hecht\n00:44:38\nFinally, there is a poem that I must remind\
+      \ you of which I enormously admire, by Matthew Arnold [https://www.wikidata.org/wiki/Q271032].\
+      \ \"Dover Beach\" [https://www.wikidata.org/wiki/Q5302469]. I have, in spite\
+      \ of my admiration for it, ventured to write a somewhat impertinent commentary\
+      \ upon it, which is called \"The Dover Bitch\" and subtitled [audience laughter],\
+      \ \"A Criticism of Life\", which is what Arnold said poetry ought to be. \n\
+      \ \nAnthony Hecht\n00:45:13\nReads \"The Dover Bitch: A Criticism of Life\"\
+      \ from The Hard Hours [audience laughter throughout].\n \nEND\n00:46:55\n[Cut\
+      \ off abruptly]."
+    duration: 00:46:55
+    featured: 'Yes'
+    file_path: files.spokenweb.ca>concordia>sgw>audio>all_mp3
+    file_url: https://files.spokenweb.ca/concordia/sgw/audio/all_mp3/anthony_hecht_i006-11-041.mp3
+    filename: anthony_hecht_i006-11-041.mp3
+    id: 1
+    notes: "Anthony Hecht reads from his book The Hard Hours which was published later\
+      \ in 1967 by Atheneum Press.\n\n00:00- Unknown Introducer introduces Anthony\
+      \ Hecht [INDEX: Poetry Reading Committee: Roy Kiyooka, Wynne Francis, Howard\
+      \ Fink, Irving Layton, Stanton Hoffman; New York City, fellow of the American\
+      \ Academy in Rome, A Summoning of Stones published by Macmillan NYC 1954, Seven\
+      \ Deadly Sins published in Northampton, Massachusetts in 1958; poetry editor\
+      \ of The Hudson Review; faculty member of Smith University, New York University,\
+      \ Bard College, University of Rochester; The Hard Hours published by Viking\
+      \ Press, Double Dactyls published by Atheneum Press, AEsopic: twenty four couplets\
+      \ written with Thomas Bewick, Harvard University Press.]\n01:36- Anthony Hecht\
+      \ introduces \u201CA Hill\u201D. [INDEX: first trip to Canada, cold weather,\
+      \ Italy; from The Hard Hours (Atheneum Press, 1967).]\n02:21- Reads \u201CA\
+      \ Hill\u201D.\n04:50- Introduces \u201CA Letter\u201D [INDEX: from The Hard\
+      \ Hours (Atheneum Press, 1967)]\n04:59- Reads \u201CA Letter\u201D.\n06:44-\
+      \ Introduces \u201CThe Vow\u201D. [INDEX: all poems read from The Hard Hours,\
+      \ miscarriage, ghost of a child.]\n07:42- Reads \u201CThe Vow\u201D.\n10:01-\
+      \ Introduces \u201CMore Light! More Light!\u201D. [INDEX: last words of Goethe,\
+      \ German Enlightenment, poem rejected by The New Yorker, England during the\
+      \ Renaissance,      Buchenwald concentration camps during WWII, book by Eugene\
+      \ Kogan, Nuremburg   Trials, prisoners brought by train, Weimar; from The Hard\
+      \ Hours (Atheneum Press,   \t1967).]\n12:01- Reads \u201CMore Light! More Light!\u201D\
+      .\n14:36- Introduces \"The Man Who Married Magdalen: Variation on a Theme by\
+      \ Louis        Simpson.\" [INDEX: Louis Simpson: poet and friend, poem in Simpson\u2019\
+      s early books  \tcalled \u201CThe Man Who Married Magdalen\u201D, husband forgiving\
+      \ wife, line from the last  \tstanza \u201CBut when he woke, and woke alone,\
+      \ he wept and would deny the loose    behaviour of the bone, and the immodest\
+      \ thigh\u201D, takes place in a bar, reading tour of   England, Wellesley, Mount\
+      \ Hollyhock, Federal Communications Commission, Boston,     Book of Jonah \u201C\
+      Then said the Lord, \u2018Dost thou well, to be angry?\u2019\u201D; from The\
+      \ Hard    \tHours (Atheneum Press, 1967).]\n17:57- Reads \"The Man Who Married\
+      \ Magdalen: Variation on a Theme by Louis \tSimpson\".\n20:26- Introduces \u201C\
+      Message from the City\u201D. [INDEX: from The Hard Hours (Atheneum Press, 1967).]\n\
+      20:37- Reads \u201CMessage from the City\u201D.\n23:02- Introduces \u201CThe\
+      \ Rune\u201D. [INDEX: from unknown source.]\n23:35- Reads \u201CThe Rune\u201D\
+      .\n27:54- Introduces \u201CThe Song of the Flea\u201D. [INDEX: Restoration comedy\
+      \ song called \u201CThe Song of the Flea\u201D, group of poems written in collaboration\
+      \ with an artist, bestiary, lithographs of animals; from The Hard Hours (Atheneum\
+      \ Press, 1967).]\n28:45- Reads \u201CThe Song of the Flea\u201D.\n29:40- Introduces\
+      \ \u201CBehold the Lilies of the Field\u201D. [INDEX: colloquy, two voices,\
+      \ one   compulsive talker, and a patient auditor; The Hard Hours (Atheneum Press,\
+      \ 1967).]\n30:18- Reads \u201CBehold the Lilies of the Field\u201D.\n34:34-\
+      \ Introduces \u201CJason\u201D. [INDEX: Hecht\u2019s older son to celebrate\
+      \ his birth, teaching at Smith, epigraph from Dr. Faustus \u201CAnd from America,\
+      \ the Golden Fleece\u201D; The Hard Hours (Atheneum Press, 1967).]\n35:16- Reads\
+      \ \u201CJason\u201D.\n37:12- Introduces \u201CThird Avenue in Sunlight\u201D\
+      . [INDEX: New England Tour, began in Maine, dry state, reading poems about bars;\
+      \ born in NYC on Third Avenue elevator train, bars; The Hard Hours (Atheneum\
+      \ Press, 1967).]\n38:45- Reads \u201CThird Avenue in Sunlight\u201D.\n40:31-\
+      \ Introduces \u201CBirdwatchers of America\u201D. [INDEX: Epigraph from the\
+      \ journals of Baudelaire \u201CI suffer now continually from vertigo, and today,\
+      \ the 23rd of January 1862, I       received a singular warning. I felt the\
+      \ wind of the wing of madness pass over me.\u201D; The       Hard Hours (Atheneum\
+      \ Press, 1967).]\n41:14- Reads \u201CBirdwatchers of America\u201D.\n42:50-\
+      \ Reads \u201CThe End of the Weekend\u201D. [INDEX: from The Hard Hours (Atheneum\
+      \ Press, 1967).]\n44:38- Introduces \u201CThe Dover Bitch: A Criticism of Life\u201D\
+      . [INDEX: Poem by Matthew Arnold \u201CDover Beach\u201D, Arnold said poetry\
+      \ ought to be \u201CA criticism of life\u201D; from The Hard     Hours (Atheneum\
+      \ Press, 1967).]\n45:13- Reads \u201CThe Dover Bitch: A Criticism of Life\u201D\
+      .\n46:55.93- END OF RECORDING."
+    size: 112.6 MB
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0041_back.jpg
+    id: 2
+    title: Anthony Hecht Tape Box - Back
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0041_front.jpg
+    id: 3
+    title: Anthony Hecht Tape Box - Front
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0041_side.jpg
+    id: 4
+    title: Anthony Hecht Tape Box - Spine
+  - content_type: Photograph
+    credit: Drew Bernet
+    file_path: My Drive>Sir George Williams TIme-Stamped Transcripts>Spokenweb Tape
+      Case Photos taken by Drew Bernet
+    file_url: https://drive.google.com/drive/folders/1-0cAe1GF8xZsc62jpUDXwgvyCd6ZmvSw
+    filename: I0006_11_0041_tape.jpg
+    id: 5
+    title: Anthony Hecht Tape Box - Reel
+  Item_Description:
+    genre:
+    - id: 6063603a900ba2.48710925
+      value: 'Reading: Poetry'
+    language: English
+    production_context: Documentary recording
+    source_item_ID: I006-11-041
+    swallow1_id: '1399'
+    title: Anthony Hecht at Sir George Williams University, The Poetry Series, 21
+      October 1966
+    title_note: '"I006/SR41 ANTHONY HECHT" written on sticker on the spine of the
+      tape''s box'
+    title_source: Transcribed from the Artifact
+  Location:
+  - address: 1455, Boul de Maisonneuve Ouest, Montreal, Quebec, Canada
+    id: 1
+    latitude: '45.4972758'
+    longitude: '-73.57893043'
+    notes: Previous researcher
+    url: https://www.openstreetmap.org/way/22080570
+    venue: SGW University
+  Material_Description:
+  - AV_type: Audio
+    accompanying_material: '"I006/SR41 ANTHONY HECHT" written on sticker on the spine
+      of the tape''s box'
+    extent: 1/4 inch
+    id: 1
+    material_designation: Reel to Reel
+    physical_composition: Magnetic Tape
+    playback_mode: Mono
+    recording_type: Analogue
+    sound_quality: Good
+    tape_brand: Scotch
+  Notes:
+  - id: 1
+    note: 'Year-Specific Information:
+
+
+      In 1966, Hecht was teaching at Bard College, and was participating in traveling
+      tours reading his poetry. Three of his works were in the process of being published:
+      The Hard Hours, Jiggery Pokery: A Compendium of Double Dactyls and AEsopic:
+      twenty four couplets.'
+    type: General
+  - id: 2
+    note: 'Local Connections:
+
+
+      Anthony Hecht was an important figure in American poetry, as well as an influential
+      professor of literature and writing. He is the inventor of the double dactyl,
+      a form of light verse as well as the recipient of many valued awards, including
+      the Pulitzer Prize for poetry, the Bollingen Prize, the Wallace Stevens Award.
+      His connection to Sir George Williams is unknown at this time.'
+    type: General
+  - id: 3
+    note: 'Original transcription by Rachel Kyne
+
+
+      Original print catalogue, introduction, research and edits by Celyn Harding-Jones
+
+
+      Additional research and edits by Ali Barillaro
+
+
+      '
+    type: Cataloguer
+  - id: 4
+    note: Reel-to-reel tape>CD>digital file
+    type: Preservation
+  Related_Works:
+  - URL: https://www.worldcat.org/title/oxford-companion-to-english-literature/oclc/1205259088&referer=brief_results
+    citation: '"Hecht, Anthony". The Oxford Companion to English Literature. Dinah
+      Birch (ed). Oxford University Press Inc., 2009. '
+    id: 1
+  - URL: https://www.worldcat.org/title/oxford-companion-to-american-literature/oclc/54356940&referer=brief_results
+    citation: '"Hecht, Anthony [Evan]". The Oxford Companion to American Literature.
+      James D. Hart (ed.), Phillip W. Leininger (rev). Oxford University Press, 1995.  '
+    id: 2
+  - citation: "Freeland, Petra. \u201CHecht, Anthony, 1923-\u201D. Literature Online\
+      \ Biography. Proquest and H.W. Wilson Company, 2005. "
+    id: 3
+  - citation: "\u201CPoetry Readings\u201D. OP-ED. Montreal: Sir George Williams University,\
+      \ 6 October 1967, page 6."
+    id: 4
+  Rights: []
+  cataloguer:
+    email: masoumehzaare@gmail.com
+    lastname: Zaare
+    name: Masoumeh
+  classification:
+  - URI: ''
+    class_name: subseries
+    id: '39'
+    label: Poetry 1
+    parent_id: '38'
+  - URI: ''
+    class_name: series
+    contact email: ''
+    description: ''
+    id: '38'
+    label: The Poetry Series
+    parent_id: '24'
+    wikidata url: ''
+  - Contributing Unit: Records Management and Archives
+    Old Swallow1 ID: ''
+    Persistent URL: http://archives.concordia.ca/I086
+    Source Collection: SGWU Reading Series-Concordia University Department of English
+      fonds
+    Source Collection Description: The fonds consists of some administrative records
+      of the SGWU Department of English and the Concordia Department of English between
+      1971 and 2000. It also consists of some SGWU Department of English records related
+      to student academic activities in the 1940s and to public readings and lectures,
+      and a few interviews, produced between 1966 and 1972. The fonds mainly includes
+      minutes of departmental meetings and some course timetables. It also includes
+      some student papers in bound volumes and 63 sound recordings (80 audio reels)
+      mainly composed of poetry readings (see the Concordia SpokenWeb project which
+      uses this material) but also a few lectures given at SGWU. There are also loose
+      typed sheets describing some of the SGWU poetry readings.
+    Source Collection ID: I086
+    URI: ''
+    class_name: collection
+    id: '24'
+    label: SGWU Reading Series-Concordia University Department of English fonds
+    parent_id: '4'
+  - URI: ''
+    class_name: partner institution
+    description: ''
+    id: '4'
+    label: Concordia University
+    parent_id: '0'
+  create_date: '2023-01-31 20:57:01'
+  last_modified: '2023-04-05 17:01:35'
+  schema: Swallow JSON
+  schema_definition: spoken_web
+  swallow_id: '1254'

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,3 +12,5 @@
   link: /oral-literary-history/
 - name: Poetry Readings in Canada
   link: /poetry-readings-in-canada/
+- name: All Audio
+  link: /audio/

--- a/_layouts/audio.html
+++ b/_layouts/audio.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  <div class="blog-wrapper">
+  {%- include head.html -%}
+
+  <body>
+
+    {%- include header.html -%}
+
+<main class="page-content" aria-label="Content">
+    <div class="wrapper">
+
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+
+  {%- assign object_data = site.data.data.objects[page.objects_id] -%}
+
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ object_data.Item_Description.title | escape }}</h1>
+    <p class="post-meta">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {{object_data.Dates[0].date | date: date_format }}
+      </time>
+      {%- if page.modified_date -%}
+        ~
+        {%- assign mdate = page.modified_date | date_to_xmlschema -%}
+        <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+          {{ mdate | date: date_format }}
+        </time>
+      {%- endif -%}
+          <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span class="p-author h-card" itemprop="name">{{ object_data.Creators[0].name }}</span></span>
+      </p>
+  </header>
+
+{%- if page.icon -%}
+  <div class="feature"><img src="{{ page.icon | absolute_url }}"/></div>
+      {%- if forloop.last == false %}, {% endif -%}
+{%- endif -%}
+
+  <div class="post-content e-content" itemprop="articleBody">
+    <p>{{ object_data.Content.notes }}</p>
+    <audio src="{{ object_data.Digital_File_Description[0].file_url }}" controls></audio>
+    {{ content }}
+  </div>
+
+  {%- if site.disqus.shortname -%}
+    {%- include disqus_comments.html -%}
+  {%- endif -%}
+
+  <a class="u-url" href="{{ page.url | absolute_url }}" hidden></a>
+</article>
+</div>
+</main>
+
+{%- include footer.html -%}
+
+</body>
+</div>
+
+</html>

--- a/_layouts/splash.html
+++ b/_layouts/splash.html
@@ -59,7 +59,7 @@
                 {%- endif %}
             
               {%- endif -%}
-            <div class="btn"><a href="{{ /blog/ | absolute_url }}">See More Entries</a></div>
+            <div class="btn"><a href="{{ '/blog/' | absolute_url }}">See More Entries</a></div>
             </div>
       </div>
     </main>

--- a/audio.md
+++ b/audio.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Audio
+permalink: /audio/
+---
+
+<h2 class='page-title'>All Audio</h2>
+
+{% assign exhibits = site.pages | where: 'layout','audio' %}
+<ul>
+  {% for exhibit in exhibits %}
+    <li>
+      <a href='{{ exhibit.url | absolute_url }}'>
+        {{ site.data.data.objects[exhibit.objects_id].Item_Description.title | escape }}
+      </a>
+    </li>
+  {% endfor %}
+</ul>

--- a/audio/audio1.md
+++ b/audio/audio1.md
@@ -1,0 +1,5 @@
+---
+layout: audio
+categories: audio
+objects_id: 0
+---

--- a/audio/audio2.md
+++ b/audio/audio2.md
@@ -1,0 +1,5 @@
+---
+layout: audio
+categories: audio
+objects_id: 1
+---

--- a/audio/audio3.md
+++ b/audio/audio3.md
@@ -1,0 +1,5 @@
+---
+layout: audio
+categories: audio
+objects_id: 2
+---


### PR DESCRIPTION
Just added a super basic interface for the audio.

I've converted their data file (or the first three elements of it) to yaml because that is what jekyll likes to work with.

Then I've used that data file to create three audio object pages. All these pages do is pull some basic metadata (just some random things I found in the data file) to demonstrate how we can play this audio from a page.

Note: I tried adding some of the photographs; however, those all link to google drive locations which cannot be accessed via a <img src=""> field.

All this is a simple proof that we can read in the json data, and generate pages from it. That is all.